### PR TITLE
Added whitespace trimming to URL-Sanitizer

### DIFF
--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/utils/LinkSanitizer.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/utils/LinkSanitizer.kt
@@ -3,12 +3,12 @@ package com.prof18.feedflow.shared.utils
 internal fun sanitizeUrl(feedUrl: String): String =
     when {
         feedUrl.startsWith("http:") -> {
-            feedUrl.replace("http:", "https:")
+            feedUrl.trim().replace("http:", "https:")
         }
 
         !feedUrl.startsWith("https://") -> {
-            "https://$feedUrl"
+            "https://${feedUrl.trim()}"
         }
 
-        else -> feedUrl
+        else -> feedUrl.trim()
     }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/utils/LinkSanitizerTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/utils/LinkSanitizerTest.kt
@@ -9,7 +9,7 @@ class LinkSanitizerTest {
         "https://www.example.com",
         "http://www.example.com",
         "www.example.com",
-        " www.example.com  "
+        " www.example.com  ",
     )
 
     private val correctLink = "https://www.example.com"

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/utils/LinkSanitizerTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/utils/LinkSanitizerTest.kt
@@ -9,6 +9,7 @@ class LinkSanitizerTest {
         "https://www.example.com",
         "http://www.example.com",
         "www.example.com",
+        " www.example.com  "
     )
 
     private val correctLink = "https://www.example.com"


### PR DESCRIPTION
When copying RSS-URLs, it can sometimes happen that whitespace is copied with it, failing the operation