### PR TITLE
DateFormatter.formatDateForFeed: Display year if date is not in current year.

### DIFF
--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/DateFormatter.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/DateFormatter.kt
@@ -367,8 +367,20 @@ class DateFormatter(
         )
 
         val isToday = today == localDate
+        val isThisYear = today.year == localDate.year
+
         val dateFormat = if (isToday) {
             LocalDateTime.Format {
+                hour()
+                char(':')
+                minute()
+            }
+        } else if (isThisYear) {
+            LocalDateTime.Format {
+                dayOfMonth()
+                char('/')
+                monthNumber()
+                chars(" - ")
                 hour()
                 char(':')
                 minute()
@@ -378,6 +390,8 @@ class DateFormatter(
                 dayOfMonth()
                 char('/')
                 monthNumber()
+                char('/')
+                year()
                 chars(" - ")
                 hour()
                 char(':')


### PR DESCRIPTION
I believe it would be useful to display the year when the date is not from the current year. 

Tested on Android and desktop:

![image](https://github.com/user-attachments/assets/07fbe6fa-35a5-4499-936a-c92c851ec85e)

![image](https://github.com/user-attachments/assets/ef1436ba-2dbd-460b-a38d-b72d028b64f8)

Thank you for this great app 🙂