### PR TITLE
Update RSS Parser | Fix  #347

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ org-robolectric = "4.14.1"
 # if necessry, dowload again the native library here
 # https://github.com/xerial/sqlite-jdbc/tree/master/src/main/resources/org/sqlite/native/Mac/aarch64
 sql-delight = "2.0.2"
-rss-parser = "6.0.8"
+rss-parser = "6.0.9"
 jsoup = "1.18.3"
 triplet-play = "3.12.1"
 compose-multiplatform = "1.7.3"


### PR DESCRIPTION
Update to https://github.com/prof18/RSS-Parser/releases/tag/6.0.9