### PR TITLE
Refactor: Use LocalUriHandler to open URLs

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/BrowserManager.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/BrowserManager.kt
@@ -1,21 +1,10 @@
 package com.prof18.feedflow.desktop
 
 import com.prof18.feedflow.shared.data.SettingsRepository
-import java.awt.Desktop
-import java.net.URI
 
 internal class BrowserManager(
     private val settingsRepository: SettingsRepository,
 ) {
     fun openReaderMode(): Boolean =
         settingsRepository.isUseReaderModeEnabled()
-}
-
-fun openInBrowser(url: String) {
-    try {
-        val desktop = Desktop.getDesktop()
-        desktop.browse(URI.create(url))
-    } catch (_: Exception) {
-        // do nothing
-    }
 }

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/about/AboutContent.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/about/AboutContent.kt
@@ -24,12 +24,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.prof18.feedflow.core.utils.Websites.FEED_FLOW_WEBSITE
 import com.prof18.feedflow.core.utils.Websites.MG_WEBSITE
 import com.prof18.feedflow.core.utils.Websites.TRANSLATION_WEBSITE
-import com.prof18.feedflow.desktop.openInBrowser
 import com.prof18.feedflow.desktop.ui.components.scrollbarStyle
 import com.prof18.feedflow.shared.ui.about.AboutButtonItem
 import com.prof18.feedflow.shared.ui.about.AboutTextItem
@@ -58,6 +58,7 @@ fun AboutContent(
                 )
             } else {
                 val listState = rememberLazyListState()
+                val uriHandler = LocalUriHandler.current
 
                 Column(
                     modifier = Modifier
@@ -90,7 +91,7 @@ fun AboutContent(
                     AuthorText(
                         modifier = Modifier.align(Alignment.CenterHorizontally),
                         nameClicked = {
-                            openInBrowser(MG_WEBSITE)
+                            uriHandler.openUri(MG_WEBSITE)
                         },
                     )
                 }
@@ -105,6 +106,7 @@ private fun SettingsItemList(
     versionLabel: String,
     showLicensesScreen: () -> Unit,
 ) {
+    val uriHandler = LocalUriHandler.current
     LazyColumn(
         modifier = Modifier,
         state = listState,
@@ -118,7 +120,7 @@ private fun SettingsItemList(
         item {
             AboutButtonItem(
                 onClick = {
-                    openInBrowser(FEED_FLOW_WEBSITE)
+                    uriHandler.openUri(FEED_FLOW_WEBSITE)
                 },
                 buttonText = LocalFeedFlowStrings.current.openWebsiteButton,
             )
@@ -127,7 +129,7 @@ private fun SettingsItemList(
         item {
             AboutButtonItem(
                 onClick = {
-                    openInBrowser(TRANSLATION_WEBSITE)
+                    uriHandler.openUri(TRANSLATION_WEBSITE)
                 },
                 buttonText = LocalFeedFlowStrings.current.aboutMenuContributeTranslations,
             )

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/accounts/dropbox/DropboxSyncScreen.desktop.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/accounts/dropbox/DropboxSyncScreen.desktop.kt
@@ -21,13 +21,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.prof18.feedflow.core.model.DropboxSynMessages
 import com.prof18.feedflow.desktop.desktopViewModel
 import com.prof18.feedflow.desktop.di.DI
-import com.prof18.feedflow.desktop.openInBrowser
 import com.prof18.feedflow.shared.presentation.DropboxSyncViewModel
 import com.prof18.feedflow.shared.ui.accounts.dropbox.DropboxSyncContent
 import com.prof18.feedflow.shared.ui.settings.SettingItem
@@ -45,6 +45,7 @@ internal class DropboxSyncScreen : Screen {
 
         val snackbarHostState = remember { SnackbarHostState() }
         val scope = rememberCoroutineScope()
+        val uriHandler = LocalUriHandler.current
 
         val errorMessage = LocalFeedFlowStrings.current.dropboxSyncError
 
@@ -61,7 +62,7 @@ internal class DropboxSyncScreen : Screen {
                     }
 
                     is DropboxSynMessages.ProceedToAuth -> {
-                        openInBrowser(event.authorizeUrl)
+                        uriHandler.openUri(event.authorizeUrl)
                     }
                 }
             }

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/HomeScreen.desktop.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/HomeScreen.desktop.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalUriHandler
 import com.prof18.feedflow.core.model.FeedFilter
 import com.prof18.feedflow.core.model.FeedItemUrlInfo
 import com.prof18.feedflow.core.model.LinkOpeningPreference
@@ -20,7 +21,6 @@ import com.prof18.feedflow.desktop.home.bywindowsize.CompactView
 import com.prof18.feedflow.desktop.home.bywindowsize.ExpandedView
 import com.prof18.feedflow.desktop.home.bywindowsize.MediumView
 import com.prof18.feedflow.desktop.home.components.NoFeedsDialog
-import com.prof18.feedflow.desktop.openInBrowser
 import com.prof18.feedflow.desktop.utils.WindowSizeClass
 import com.prof18.feedflow.desktop.utils.WindowWidthSizeClass
 import com.prof18.feedflow.shared.presentation.HomeViewModel
@@ -50,6 +50,7 @@ internal fun HomeScreen(
 
     val browserManager = DI.koin.get<BrowserManager>()
     val strings = LocalFeedFlowStrings.current
+    val uriHandler = LocalUriHandler.current
 
     if (isDeleting) {
         DeleteOldFeedDialog()
@@ -134,13 +135,13 @@ internal fun HomeScreen(
                 openUrl = { feedItemUrlInfo ->
                     when (feedItemUrlInfo.linkOpeningPreference) {
                         LinkOpeningPreference.READER_MODE -> navigateToReaderMode(feedItemUrlInfo)
-                        LinkOpeningPreference.INTERNAL_BROWSER -> openInBrowser(feedItemUrlInfo.url)
-                        LinkOpeningPreference.PREFERRED_BROWSER -> openInBrowser(feedItemUrlInfo.url)
+                        LinkOpeningPreference.INTERNAL_BROWSER -> uriHandler.openUri(feedItemUrlInfo.url)
+                        LinkOpeningPreference.PREFERRED_BROWSER -> uriHandler.openUri(feedItemUrlInfo.url)
                         LinkOpeningPreference.DEFAULT -> {
                             if (browserManager.openReaderMode()) {
                                 navigateToReaderMode(feedItemUrlInfo)
                             } else {
-                                openInBrowser(feedItemUrlInfo.url)
+                                uriHandler.openUri(feedItemUrlInfo.url)
                             }
                         }
                     }
@@ -204,13 +205,13 @@ internal fun HomeScreen(
                 openUrl = { feedItemUrlInfo ->
                     when (feedItemUrlInfo.linkOpeningPreference) {
                         LinkOpeningPreference.READER_MODE -> navigateToReaderMode(feedItemUrlInfo)
-                        LinkOpeningPreference.INTERNAL_BROWSER -> openInBrowser(feedItemUrlInfo.url)
-                        LinkOpeningPreference.PREFERRED_BROWSER -> openInBrowser(feedItemUrlInfo.url)
+                        LinkOpeningPreference.INTERNAL_BROWSER -> uriHandler.openUri(feedItemUrlInfo.url)
+                        LinkOpeningPreference.PREFERRED_BROWSER -> uriHandler.openUri(feedItemUrlInfo.url)
                         LinkOpeningPreference.DEFAULT -> {
                             if (browserManager.openReaderMode()) {
                                 navigateToReaderMode(feedItemUrlInfo)
                             } else {
-                                openInBrowser(feedItemUrlInfo.url)
+                                uriHandler.openUri(feedItemUrlInfo.url)
                             }
                         }
                     }
@@ -274,13 +275,13 @@ internal fun HomeScreen(
                 openUrl = { feedItemUrlInfo ->
                     when (feedItemUrlInfo.linkOpeningPreference) {
                         LinkOpeningPreference.READER_MODE -> navigateToReaderMode(feedItemUrlInfo)
-                        LinkOpeningPreference.INTERNAL_BROWSER -> openInBrowser(feedItemUrlInfo.url)
-                        LinkOpeningPreference.PREFERRED_BROWSER -> openInBrowser(feedItemUrlInfo.url)
+                        LinkOpeningPreference.INTERNAL_BROWSER -> uriHandler.openUri(feedItemUrlInfo.url)
+                        LinkOpeningPreference.PREFERRED_BROWSER -> uriHandler.openUri(feedItemUrlInfo.url)
                         LinkOpeningPreference.DEFAULT -> {
                             if (browserManager.openReaderMode()) {
                                 navigateToReaderMode(feedItemUrlInfo)
                             } else {
-                                openInBrowser(feedItemUrlInfo.url)
+                                uriHandler.openUri(feedItemUrlInfo.url)
                             }
                         }
                     }

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/bywindowsize/CompactHomeView.desktop.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/bywindowsize/CompactHomeView.desktop.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.prof18.feedflow.core.model.CategoryId
@@ -22,7 +23,6 @@ import com.prof18.feedflow.core.model.FeedSource
 import com.prof18.feedflow.core.model.NavDrawerState
 import com.prof18.feedflow.desktop.editfeed.EditFeedScreen
 import com.prof18.feedflow.desktop.home.components.HomeScreenContent
-import com.prof18.feedflow.desktop.openInBrowser
 import com.prof18.feedflow.shared.domain.model.FeedUpdateStatus
 import com.prof18.feedflow.shared.presentation.preview.feedItemsForPreview
 import com.prof18.feedflow.shared.presentation.preview.inProgressFeedUpdateStatus
@@ -62,6 +62,7 @@ internal fun CompactView(
     val scope = rememberCoroutineScope()
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val navigator = LocalNavigator.currentOrThrow
+    val uriHandler = LocalUriHandler.current
 
     ModalNavigationDrawer(
         drawerContent = {
@@ -114,7 +115,7 @@ internal fun CompactView(
                 markAsRead(FeedItemId(feedInfo.id))
             },
             onCommentClick = { feedInfo ->
-                openInBrowser(feedInfo.url)
+                uriHandler.openUri(feedInfo.url)
                 markAsRead(FeedItemId(feedInfo.id))
             },
             onAddFeedClick = {

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/bywindowsize/ExpandedHomeView.desktop.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/bywindowsize/ExpandedHomeView.desktop.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.prof18.feedflow.core.model.CategoryId
@@ -23,7 +24,6 @@ import com.prof18.feedflow.core.model.FeedSource
 import com.prof18.feedflow.core.model.NavDrawerState
 import com.prof18.feedflow.desktop.editfeed.EditFeedScreen
 import com.prof18.feedflow.desktop.home.components.HomeScreenContent
-import com.prof18.feedflow.desktop.openInBrowser
 import com.prof18.feedflow.shared.domain.model.FeedUpdateStatus
 import com.prof18.feedflow.shared.presentation.preview.feedItemsForPreview
 import com.prof18.feedflow.shared.presentation.preview.inProgressFeedUpdateStatus
@@ -62,6 +62,7 @@ internal fun ExpandedView(
 ) {
     val scope = rememberCoroutineScope()
     val navigator = LocalNavigator.currentOrThrow
+    val uriHandler = LocalUriHandler.current
 
     Row {
         Scaffold(
@@ -107,7 +108,7 @@ internal fun ExpandedView(
                 markAsRead(FeedItemId(feedInfo.id))
             },
             onCommentClick = { feedInfo ->
-                openInBrowser(feedInfo.url)
+                uriHandler.openUri(feedInfo.url)
                 markAsRead(FeedItemId(feedInfo.id))
             },
             onAddFeedClick = {

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/bywindowsize/MediumHomeView.desktop.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/bywindowsize/MediumHomeView.desktop.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.prof18.feedflow.core.model.CategoryId
@@ -28,7 +29,6 @@ import com.prof18.feedflow.core.model.FeedSource
 import com.prof18.feedflow.core.model.NavDrawerState
 import com.prof18.feedflow.desktop.editfeed.EditFeedScreen
 import com.prof18.feedflow.desktop.home.components.HomeScreenContent
-import com.prof18.feedflow.desktop.openInBrowser
 import com.prof18.feedflow.shared.domain.model.FeedUpdateStatus
 import com.prof18.feedflow.shared.presentation.preview.feedItemsForPreview
 import com.prof18.feedflow.shared.presentation.preview.inProgressFeedUpdateStatus
@@ -70,6 +70,7 @@ internal fun MediumView(
     }
     val scope = rememberCoroutineScope()
     val navigator = LocalNavigator.currentOrThrow
+    val uriHandler = LocalUriHandler.current
 
     Row {
         AnimatedVisibility(
@@ -123,7 +124,7 @@ internal fun MediumView(
                 markAsRead(FeedItemId(feedInfo.id))
             },
             onCommentClick = { feedInfo ->
-                openInBrowser(feedInfo.url)
+                uriHandler.openUri(feedInfo.url)
                 markAsRead(FeedItemId(feedInfo.id))
             },
             onAddFeedClick = {

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/reaadermode/ReaderModeScreen.desktop.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/reaadermode/ReaderModeScreen.desktop.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.core.screen.Screen
@@ -29,7 +30,6 @@ import com.prof18.feedflow.core.model.FeedItemId
 import com.prof18.feedflow.core.model.FeedItemUrlInfo
 import com.prof18.feedflow.desktop.desktopViewModel
 import com.prof18.feedflow.desktop.di.DI
-import com.prof18.feedflow.desktop.openInBrowser
 import com.prof18.feedflow.shared.presentation.ReaderModeViewModel
 import com.prof18.feedflow.shared.ui.readermode.ReaderModeContent
 import com.prof18.feedflow.shared.ui.style.Spacing
@@ -41,7 +41,6 @@ import java.awt.datatransfer.StringSelection
 internal data class ReaderModeScreen(
     private val feedItemUrlInfo: FeedItemUrlInfo,
 ) : Screen {
-
     @Composable
     override fun Content() {
         val readerModeViewModel = desktopViewModel { DI.koin.get<ReaderModeViewModel>() }
@@ -57,6 +56,7 @@ internal data class ReaderModeScreen(
         val scope = rememberCoroutineScope()
 
         val message = LocalFeedFlowStrings.current.linkCopiedSuccess
+        val uriHandler = LocalUriHandler.current
 
         ReaderModeContent(
             readerModeState = state,
@@ -65,7 +65,7 @@ internal data class ReaderModeScreen(
             },
             snackbarHost = { SnackbarHost(snackbarHostState) },
             openInBrowser = { url ->
-                openInBrowser(url)
+                uriHandler.openUri(url)
             },
             onShareClick = { url ->
                 val clipboard = Toolkit.getDefaultToolkit().systemClipboard

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/search/SearchScreen.desktop.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/search/SearchScreen.desktop.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -17,7 +18,6 @@ import com.prof18.feedflow.core.model.FeedItemId
 import com.prof18.feedflow.core.model.SearchState
 import com.prof18.feedflow.desktop.BrowserManager
 import com.prof18.feedflow.desktop.di.DI
-import com.prof18.feedflow.desktop.openInBrowser
 import com.prof18.feedflow.desktop.reaadermode.ReaderModeScreen
 import com.prof18.feedflow.shared.presentation.SearchViewModel
 import com.prof18.feedflow.shared.presentation.model.UIErrorState
@@ -39,6 +39,7 @@ internal data class SearchScreen(
         val searchQuery by viewModel.searchQueryState.collectAsState()
         val feedFontSizes by viewModel.feedFontSizeState.collectAsState()
         val strings = LocalFeedFlowStrings.current
+        val uriHandler = LocalUriHandler.current
 
         val snackbarHostState = remember { SnackbarHostState() }
 
@@ -86,7 +87,7 @@ internal data class SearchScreen(
                 if (browserManager.openReaderMode()) {
                     navigator.push(ReaderModeScreen(urlInfo))
                 } else {
-                    openInBrowser(urlInfo.url)
+                    uriHandler.openUri(urlInfo.url)
                 }
                 viewModel.onReadStatusClick(FeedItemId(urlInfo.id), true)
             },
@@ -97,7 +98,7 @@ internal data class SearchScreen(
                 viewModel.onReadStatusClick(feedItemId, isRead)
             },
             onCommentClick = { urlInfo ->
-                openInBrowser(urlInfo.url)
+                uriHandler.openUri(urlInfo.url)
                 viewModel.onReadStatusClick(FeedItemId(urlInfo.id), true)
             },
             snackbarHost = {


### PR DESCRIPTION
This commit refactors the codebase to use `LocalUriHandler` for opening URLs instead of the custom `openInBrowser` function. This approach is more idiomatic within the Compose environment.

Resolves the problem of not being able to open a web page using a browser on Linux
![image](https://github.com/user-attachments/assets/3b9d65a6-8404-4fae-9897-2d90b9526fdc)
