### PR TITLE
Fix accessibility issues for screen readers (Talkback)

### DIFF
--- a/i18n/src/commonMain/resources/locale/values/strings.xml
+++ b/i18n/src/commonMain/resources/locale/values/strings.xml
@@ -242,6 +242,12 @@
     <string name="reader_mode_archive_button">Open in archive.is</string>
     <string name="reader_mode_browser_button_content_description">Open in browser</string>
     <string name="reader_mode_comments_button_content_description">Open comments</string>
+    <string name="search_button_content_description">Search</string>
+    <string name="more_options_button_content_description">More options</string>
+    <string name="drawer_menu_button_content_description">Open navigation menu</string>
+    <string name="increase_font_size_button_content_description">Increase font size</string>
+    <string name="decrease_font_size_button_content_description">Decrease font size</string>
+    <string name="scroll_to_top_button_content_description">Scroll to top</string>
     <string name="previous_article">Previous article</string>
     <string name="next_article">Next article</string>
     <string name="settings_theme">Theme</string>

--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/feedsourcelist/FeedSourceContextMenu.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/feedsourcelist/FeedSourceContextMenu.kt
@@ -22,7 +22,11 @@ internal fun FeedSourceContextMenu(
     DropdownMenu(
         expanded = showFeedMenu,
         onDismissRequest = hideMenu,
-        properties = PopupProperties(),
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
     ) {
         DropdownMenuItem(
             text = {

--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/CategoryContextMenu.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/CategoryContextMenu.kt
@@ -26,7 +26,11 @@ internal fun CategoryContextMenu(
     DropdownMenu(
         expanded = showMenu,
         onDismissRequest = hideMenu,
-        properties = PopupProperties(),
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
     ) {
         DropdownMenuItem(
             text = {

--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/HomeAppBar.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/HomeAppBar.kt
@@ -81,7 +81,7 @@ internal fun HomeAppBar(
             ) {
                 Icon(
                     imageVector = Icons.Default.Search,
-                    contentDescription = "Search",
+                    contentDescription = LocalFeedFlowStrings.current.searchButtonContentDescription,
                 )
             }
 
@@ -93,7 +93,7 @@ internal fun HomeAppBar(
                 ) {
                     Icon(
                         imageVector = Icons.Default.MoreVert,
-                        contentDescription = "Settings",
+                        contentDescription = LocalFeedFlowStrings.current.moreOptionsButtonContentDescription,
                     )
                 }
 
@@ -151,7 +151,7 @@ private fun DrawerIcon(onDrawerMenuClick: () -> Unit, isDrawerOpen: Boolean) {
             } else {
                 Icons.Default.Menu
             },
-            contentDescription = "Drawer menu",
+            contentDescription = LocalFeedFlowStrings.current.drawerMenuButtonContentDescription,
         )
     }
 }

--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/HomeAppBarDropdownMenu.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/HomeAppBarDropdownMenu.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.window.PopupProperties
 import com.prof18.feedflow.core.model.FeedFilter
 import com.prof18.feedflow.core.model.FeedSource
 import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
@@ -90,6 +91,11 @@ internal fun HomeAppBarDropdownMenu(
     DropdownMenu(
         expanded = showMenu,
         onDismissRequest = closeMenu,
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
     ) {
         DropdownMenuItem(
             onClick = {

--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/ScrollToTopButton.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/ScrollToTopButton.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
 
 @Composable
 fun ScrollToTopButton(
@@ -32,7 +33,7 @@ fun ScrollToTopButton(
         ) {
             Icon(
                 imageVector = Icons.Default.ArrowUpward,
-                contentDescription = null,
+                contentDescription = LocalFeedFlowStrings.current.scrollToTopButtonContentDescription,
             )
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/list/FeedItemContextMenu.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/list/FeedItemContextMenu.kt
@@ -38,7 +38,11 @@ internal fun FeedItemContextMenu(
     DropdownMenu(
         expanded = showMenu,
         onDismissRequest = closeMenu,
-        properties = PopupProperties(),
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
     ) {
         ChangeReadStatusMenuItem(
             feedItem = feedItem,

--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/readermode/FontSizeSliders.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/readermode/FontSizeSliders.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
 
 // Adapted from https://github.com/omnivore-app/omnivore/blob/main/android/Omnivore/app/src/main/java/app/omnivore/omnivore/feature/components/SliderWithPlusMinus.kt#L91
 @Composable
@@ -95,7 +96,7 @@ fun AddButton(
     ) {
         Icon(
             imageVector = Icons.Default.Add,
-            contentDescription = null,
+            contentDescription = LocalFeedFlowStrings.current.increaseFontSizeButtonContentDescription,
             tint = if (enabled) colors.disabledContentColor else colors.disabledContentColor,
         )
     }
@@ -118,7 +119,7 @@ fun SubtractButton(
     ) {
         Icon(
             imageVector = Icons.Default.Remove,
-            contentDescription = null,
+            contentDescription = LocalFeedFlowStrings.current.decreaseFontSizeButtonContentDescription,
             tint = if (enabled) colors.disabledContentColor else colors.disabledContentColor,
         )
     }


### PR DESCRIPTION
This commit addresses all accessibility issues reported in #600 for Talkback screen reader compatibility:

**1. Make button labels translatable and fix naming:**
- Added translatable content descriptions for Search, More Options, and Drawer Menu buttons
- Changed "Settings" button label to "More options" for better clarity
- All button labels now use LocalFeedFlowStrings for proper internationalization
- Files: HomeAppBar.kt

**2. Add labels for text scaling buttons:**
- Added content descriptions to the increase (+) and decrease (-) font size buttons
- Screen readers will now properly vocalize "Increase font size" and "Decrease font size"
- Files: FontSizeSliders.kt

**3. Improve context menu accessibility:**
- Updated all DropdownMenu components to use explicit PopupProperties
- Set focusable=true to ensure proper focus management for screen readers
- Set dismissOnBackPress=true to enable back gesture dismissal
- Set dismissOnClickOutside=true for better UX
- Files: FeedSourceContextMenu.kt, FeedItemContextMenu.kt, CategoryContextMenu.kt, HomeAppBarDropdownMenu.kt

**4. Add accessibility for new ScrollToTopButton:**
- Added content description for the newly added Scroll to Top FAB
- Screen readers will now announce "Scroll to top" when focused
- Files: ScrollToTopButton.kt

**New translatable strings added to strings.xml:**
- search_button_content_description: "Search"
- more_options_button_content_description: "More options"
- drawer_menu_button_content_description: "Open navigation menu"
- increase_font_size_button_content_description: "Increase font size"
- decrease_font_size_button_content_description: "Decrease font size"
- scroll_to_top_button_content_description: "Scroll to top"

Fixes #600