### PR TITLE
Exclude divider from clickable area

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/list/FeedItemView.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/list/FeedItemView.kt
@@ -56,93 +56,96 @@ internal fun FeedItemView(
         )
     }
 
-    Column(
-        modifier = modifier
-            .then(
-                if (disableClick) {
-                    Modifier
-                } else {
-                    Modifier.singleAndLongClickModifier(
-                        onClick = {
-                            onFeedItemClick(
-                                FeedItemUrlInfo(
-                                    id = feedItem.id,
-                                    url = feedItem.url,
-                                    title = feedItem.title,
-                                    isBookmarked = feedItem.isBookmarked,
-                                    linkOpeningPreference = feedItem.feedSource.linkOpeningPreference,
-                                    commentsUrl = feedItem.commentsUrl,
-                                ),
-                            )
-                        },
-                        onLongClick = {
-                            showItemMenu = true
-                        },
+    val clickableItemModifier =
+        if (disableClick) {
+            Modifier
+        } else {
+            Modifier.singleAndLongClickModifier(
+                onClick = {
+                    onFeedItemClick(
+                        FeedItemUrlInfo(
+                            id = feedItem.id,
+                            url = feedItem.url,
+                            title = feedItem.title,
+                            isBookmarked = feedItem.isBookmarked,
+                            linkOpeningPreference = feedItem.feedSource.linkOpeningPreference,
+                            commentsUrl = feedItem.commentsUrl,
+                        ),
                     )
                 },
+                onLongClick = {
+                    showItemMenu = true
+                },
             )
-            .padding(horizontal = Spacing.regular)
-            .padding(vertical = Spacing.small),
-    ) {
-        FeedSourceAndUnreadDotRow(
-            feedItem = feedItem,
-            feedFontSize = feedFontSize,
-            currentFeedFilter = currentFeedFilter,
-        )
+        }
 
-        TitleSubtitleAndImageRow(
-            modifier = Modifier
-                .height(IntrinsicSize.Min)
-                .fillMaxWidth(),
-            feedItem = feedItem,
-            feedFontSize = feedFontSize,
-            currentFeedFilter = currentFeedFilter,
-        )
-
-        feedItem.dateString?.let { dateString ->
-            Text(
-                modifier = Modifier
-                    .padding(top = Spacing.small),
-                text = dateString,
-                fontSize = feedFontSize.feedMetaFontSize.sp,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(
-                    alpha = if (feedItem.isRead &&
-                        currentFeedFilter !is FeedFilter.Read && currentFeedFilter !is FeedFilter.Bookmarks
-                    ) {
-                        0.6f
-                    } else {
-                        1f
-                    },
+    Column(modifier = modifier) {
+        Column(
+            modifier = clickableItemModifier
+                .padding(horizontal = Spacing.regular)
+                .padding(
+                    top = Spacing.small,
+                    bottom = Spacing.regular,
                 ),
+        ) {
+            FeedSourceAndUnreadDotRow(
+                feedItem = feedItem,
+                feedFontSize = feedFontSize,
+                currentFeedFilter = currentFeedFilter,
+            )
+
+            TitleSubtitleAndImageRow(
+                modifier = Modifier
+                    .height(IntrinsicSize.Min)
+                    .fillMaxWidth(),
+                feedItem = feedItem,
+                feedFontSize = feedFontSize,
+                currentFeedFilter = currentFeedFilter,
+            )
+
+            feedItem.dateString?.let { dateString ->
+                Text(
+                    modifier = Modifier
+                        .padding(top = Spacing.small),
+                    text = dateString,
+                    fontSize = feedFontSize.feedMetaFontSize.sp,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(
+                        alpha = if (feedItem.isRead &&
+                            currentFeedFilter !is FeedFilter.Read && currentFeedFilter !is FeedFilter.Bookmarks
+                        ) {
+                            0.6f
+                        } else {
+                            1f
+                        },
+                    ),
+                )
+            }
+
+            FeedItemContextMenu(
+                showMenu = showItemMenu,
+                closeMenu = {
+                    showItemMenu = false
+                },
+                feedItem = feedItem,
+                shareMenuLabel = shareMenuLabel,
+                shareCommentsMenuLabel = shareCommentsMenuLabel,
+                onBookmarkClick = onBookmarkClick,
+                onReadStatusClick = onReadStatusClick,
+                onCommentClick = onCommentClick,
+                onShareClick = onShareClick,
+                onOpenFeedSettings = onOpenFeedSettings,
+                onMarkAllAboveAsRead = onMarkAllAboveAsRead,
+                onMarkAllBelowAsRead = onMarkAllBelowAsRead,
             )
         }
 
         if (feedLayout == FeedLayout.LIST) {
             HorizontalDivider(
-                modifier = Modifier
-                    .padding(top = Spacing.regular),
                 thickness = 0.2.dp,
                 color = Color.Gray,
             )
         }
-
-        FeedItemContextMenu(
-            showMenu = showItemMenu,
-            closeMenu = {
-                showItemMenu = false
-            },
-            feedItem = feedItem,
-            shareMenuLabel = shareMenuLabel,
-            shareCommentsMenuLabel = shareCommentsMenuLabel,
-            onBookmarkClick = onBookmarkClick,
-            onReadStatusClick = onReadStatusClick,
-            onCommentClick = onCommentClick,
-            onShareClick = onShareClick,
-            onOpenFeedSettings = onOpenFeedSettings,
-            onMarkAllAboveAsRead = onMarkAllAboveAsRead,
-            onMarkAllBelowAsRead = onMarkAllBelowAsRead,
-        )
     }
 }
 


### PR DESCRIPTION
I'm a big fan of this app, and I'm happy to contribute.

This PR fixes an issue where the divider was part of the clickable area. 
Following standard Android UI patterns, the divider has been excluded from the touch target so that hover/ripple effects no longer contains the divider

If this behavior was intentional, please feel free to close this PR. I'm happy to follow the project's direction!

## Changes

The component nesting has changed due to the addition of the `Column`. I recommend viewing the changes with the **"Hide whitespace"** option enabled to see the actual logic changes more clearly.

- Wrapped the components in a `Column` to properly separate the clickable content from the divider.
- Extracted `Modifier` into variables to make the Composable structure clearer and more readable.
- Fine-tuned the `padding` to ensure the layout remains consistent after the structural changes.

## Screenshots

| platform | before | after |
|-|-|-|
| desktop | <img width="360" alt="Screenshot 2026-01-18 at 1 57 51" src="https://github.com/user-attachments/assets/c64f2bf6-487d-42da-ba4f-bc9a04ce2f13" /> | <img width="360" alt="Screenshot 2026-01-18 at 1 56 59" src="https://github.com/user-attachments/assets/5c944fe6-afac-489e-898c-c949e528537b" /> |
| android |<img width="1280" height="2856" alt="Screenshot_20260118_020918" src="https://github.com/user-attachments/assets/4db5d972-3edc-4f17-a9aa-dbbd6e9f61c3" /> |<img width="1280" height="2856" alt="Screenshot_20260118_020241" src="https://github.com/user-attachments/assets/40caf128-49bd-41e1-a779-dc27fa652774" /> |







