### PR TITLE
App Title 

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/Main.kt
@@ -124,7 +124,7 @@ fun main() {
                         }
                     }
                 },
-                title = "",
+                title = "FeedFlow",
                 state = windowState,
                 icon = icon,
                 visible = showMainWindow,


### PR DESCRIPTION
App title field now displays the app title when hovering the app icon on a Windows taskbar, and on other similar cases.