### PR TITLE
Add Exit menu item for Windows File menu

### DIFF
--- a/core/src/jvmMain/kotlin/com/prof18/feedflow/core/utils/DesktopOS.kt
+++ b/core/src/jvmMain/kotlin/com/prof18/feedflow/core/utils/DesktopOS.kt
@@ -20,3 +20,5 @@ fun DesktopOS.isMacOs() = this == DesktopOS.MAC
 fun DesktopOS.isNotMacOs() = !isMacOs()
 
 fun DesktopOS.isLinux() = this == DesktopOS.LINUX
+
+fun DesktopOS.isWindows() = this == DesktopOS.WINDOWS

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/menubar/FileMenu.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/menubar/FileMenu.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyShortcut
 import androidx.compose.ui.window.MenuBarScope
 import androidx.compose.ui.window.MenuScope
+import com.prof18.feedflow.core.utils.getDesktopOS
+import com.prof18.feedflow.core.utils.isWindows
 import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
 
 @Composable
@@ -80,6 +82,15 @@ internal fun MenuBarScope.FileMenu(
                 KeyShortcut(Key.I, ctrl = true)
             },
         )
+
+        if (getDesktopOS().isWindows()) {
+            Separator()
+
+            Item(
+                text = LocalFeedFlowStrings.current.exitMenu,
+                onClick = actions.onExitClick,
+            )
+        }
 
         DebugMenu(
             showDebugMenu = state.showDebugMenu,

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/menubar/MenuBar.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/home/menubar/MenuBar.kt
@@ -279,6 +279,7 @@ data class MenuBarActions(
     val onFeedFontScaleClick: () -> Unit,
     val deleteFeeds: () -> Unit,
     val onBackupClick: () -> Unit,
+    val onExitClick: () -> Unit,
 )
 
 data class MenuBarState(

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/main/MainWindow.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/main/MainWindow.kt
@@ -367,6 +367,9 @@ private fun FrameWindowScope.MainWindowContent(
                         onBackupClick = {
                             homeViewModel.enqueueBackup()
                         },
+                        onExitClick = {
+                            window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING))
+                        },
                     ),
                 )
 

--- a/i18n/src/commonMain/resources/locale/values/strings.xml
+++ b/i18n/src/commonMain/resources/locale/values/strings.xml
@@ -261,6 +261,7 @@
     <string name="widget_background_opacity_title">Background opacity: %s%%</string>
     <string name="widget_font_size_title">Font size</string>
     <string name="file_menu">File</string>
+    <string name="exit_menu">Exit</string>
     <string name="menu_view">View</string>
     <string name="settings_left_swipe_action">Left swipe</string>
     <string name="settings_right_swipe_action">Right swipe</string>


### PR DESCRIPTION
- Add 'exit_menu' i18n string resource
- Add isWindows() extension function to DesktopOS
- Add onExitClick callback to MenuBarActions
- Add Windows-only Exit menu item at end of File menu
- Wire up Exit to trigger window closing event with cleanup