### PR TITLE
Fix Bazqux sync test flake

### DIFF
--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/BazquxSyncViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/BazquxSyncViewModelTest.kt
@@ -97,7 +97,7 @@ class BazquxSyncViewModelTest : KoinTestBase() {
                 password = "testpassword",
             )
 
-            val state = awaitItemMatching { it is AccountConnectionUiState.Linked }
+            val state = awaitLinkedStateAfterSync()
             assertIs<AccountConnectionUiState.Linked>(state)
         }
     }
@@ -202,7 +202,7 @@ class BazquxSyncViewModelTest : KoinTestBase() {
                 password = "testpassword",
             )
 
-            val state = awaitItemMatching { it is AccountConnectionUiState.Linked }
+            val state = awaitLinkedStateAfterSync()
             assertIs<AccountConnectionUiState.Linked>(state)
 
             val accountType = networkSettings.getSyncAccountType()
@@ -269,3 +269,9 @@ private suspend fun <T> TurbineTestContext<T>.awaitItemMatching(
         }
     }
 }
+
+private suspend fun TurbineTestContext<AccountConnectionUiState>.awaitLinkedStateAfterSync():
+    AccountConnectionUiState.Linked =
+    awaitItemMatching { state ->
+        state is AccountConnectionUiState.Linked && state.syncState !is AccountSyncUIState.Loading
+    } as AccountConnectionUiState.Linked


### PR DESCRIPTION
## Summary
- wait for the final Bazqux linked state after sync in BazquxSyncViewModelTest
- avoid Turbine failures caused by the transient Linked(Loading) emission during login

## Verification
- ./gradlew :shared:jvmTest --tests "com.prof18.feedflow.shared.presentation.BazquxSyncViewModelTest" --quiet --console=plain
- ANDROID_HOME=/Users/mg/Library/Android/sdk ANDROID_SDK_ROOT=/Users/mg/Library/Android/sdk ./gradlew detekt allTests --quiet --console=plain