### PR TITLE
Prevent Android widget empty-state flash on refresh

### DIFF
--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/widget/FeedFlowWidget.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/widget/FeedFlowWidget.kt
@@ -12,7 +12,7 @@ import com.prof18.feedflow.shared.data.WidgetSettingsRepository
 import com.prof18.feedflow.shared.domain.feed.FeedWidgetRepository
 import com.prof18.feedflow.shared.ui.utils.ProvideFeedFlowStrings
 import com.prof18.feedflow.shared.ui.utils.rememberFeedFlowStrings
-import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.first
 
 internal class FeedFlowWidget(
     private val repository: FeedWidgetRepository,
@@ -20,11 +20,16 @@ internal class FeedFlowWidget(
     private val browserManager: BrowserManager,
 ) : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val feedItemsFlow = repository.getFeeds()
+        // Glance rebuilds can briefly render the collectAsState initial value before the DB flow emits.
+        // Preloading the current items avoids flashing the widget empty state during refreshes.
+        val initialFeedItems = feedItemsFlow.first()
+
         provideContent {
             val lyricist = rememberFeedFlowStrings()
 
             ProvideFeedFlowStrings(lyricist) {
-                val feedItems by repository.getFeeds().collectAsState(persistentListOf())
+                val feedItems by feedItemsFlow.collectAsState(initialFeedItems)
                 val feedLayout by widgetSettingsRepository.feedWidgetLayout.collectAsState()
                 val showHeader by widgetSettingsRepository.widgetShowHeader.collectAsState()
                 val fontScale by widgetSettingsRepository.widgetFontScale.collectAsState()


### PR DESCRIPTION
## Summary
- preload current widget items before Glance starts collecting so widget refreshes do not briefly render the empty state first
- keep the existing rows visible until the refreshed feed list arrives from the database flow
- document why the widget uses a preloaded initial list to avoid future regressions