### PR TITLE
Handle invalid article CSV imports without error-level logging

### DIFF
--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feed/FeedImportExportRepository.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feed/FeedImportExportRepository.kt
@@ -132,7 +132,9 @@ internal class FeedImportExportRepository(
         csvInput: CsvInput,
     ) = withContext(dispatcherProvider.io) {
         val csvText = csvInput.readText()
-        val csv = CsvWithHeader.fromCsvText(csvText) as CsvWithHeader
+        val csv = requireNotNull(CsvWithHeader.fromCsvText(csvText)) {
+            "CSV input is missing a header row"
+        }
         val header = csv.header
 
         val urlHashIndex = header.columnIndex(articleCsvHeaders[0])

--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/presentation/ImportExportViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/presentation/ImportExportViewModel.kt
@@ -78,6 +78,12 @@ class ImportExportViewModel internal constructor(
                 importerMutableState.update {
                     FeedImportExportState.ArticleImportSuccess
                 }
+            } catch (e: IllegalArgumentException) {
+                logger.d(e) { "Invalid article CSV import file" }
+                importerMutableState.update { FeedImportExportState.Error }
+            } catch (e: IllegalStateException) {
+                logger.d(e) { "Invalid article CSV import file" }
+                importerMutableState.update { FeedImportExportState.Error }
             } catch (e: Throwable) {
                 logger.e(e) { "Error while importing articles" }
                 importerMutableState.update { FeedImportExportState.Error }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/ImportExportViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/ImportExportViewModelTest.kt
@@ -182,6 +182,18 @@ class ImportExportViewModelTest : KoinTestBase() {
     }
 
     @Test
+    fun `importArticles reports error when csv header is missing`() = runTest {
+        val csvInput = createCsvInput(HEADERLESS_CSV_CONTENT)
+
+        assertEquals(FeedImportExportState.Idle, viewModel.importExportState.value)
+
+        viewModel.importArticles(csvInput)
+
+        advanceUntilIdle()
+        assertEquals(FeedImportExportState.Error, viewModel.importExportState.value)
+    }
+
+    @Test
     fun `exportArticles reports error when output fails`() = runTest {
         val csvOutput = createFailingCsvOutput()
 
@@ -288,5 +300,6 @@ class ImportExportViewModelTest : KoinTestBase() {
             "false,false,0,,false,false\n"
 
         const val INVALID_CSV_CONTENT = "url,title\nhttps://example.com,Title\n"
+        const val HEADERLESS_CSV_CONTENT = ""
     }
 }


### PR DESCRIPTION
## Summary
- guard article CSV parsing against missing header rows instead of force-casting parser output
- treat invalid article CSV imports as handled user input and log them at debug level
- add regression coverage for headerless CSV imports in `ImportExportViewModelTest`

## Testing
- `./gradlew :shared:jvmTest --tests "com.prof18.feedflow.shared.presentation.ImportExportViewModelTest" -q --console=plain`