### PR TITLE
Fix feed favicon normalization for relative logo URLs

### DIFF
--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feed/FeedSourceLogoRetrieverImpl.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feed/FeedSourceLogoRetrieverImpl.kt
@@ -40,10 +40,31 @@ internal class FeedSourceLogoRetrieverImpl(
     }
 
     private fun normalizeLogoUrl(baseDomain: String?, logoUrl: String?): String? {
-        if (baseDomain != null && (logoUrl == null || logoUrl.startsWith("/"))) {
-            return "$baseDomain/favicon.ico"
+        if (logoUrl.isNullOrBlank()) {
+            return baseDomain?.let { "$it/favicon.ico" }
         }
-        return logoUrl
+        if (baseDomain == null) {
+            return logoUrl
+        }
+        return when {
+            logoUrl.startsWith("http://", ignoreCase = true) ||
+                logoUrl.startsWith("https://", ignoreCase = true) ||
+                logoUrl.startsWith("data:", ignoreCase = true) -> {
+                logoUrl
+            }
+
+            logoUrl.startsWith("//") -> {
+                val scheme = if (baseDomain.startsWith("https://", ignoreCase = true)) {
+                    "https:"
+                } else {
+                    "http:"
+                }
+                "$scheme$logoUrl"
+            }
+
+            logoUrl.startsWith("/") -> "$baseDomain$logoUrl"
+            else -> "$baseDomain/${logoUrl.removePrefix("./")}"
+        }
     }
 
     private fun getFaviconFromGoogle(websiteLink: String): String {

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedSourceLogoRetrieverImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedSourceLogoRetrieverImplTest.kt
@@ -1,0 +1,76 @@
+package com.prof18.feedflow.shared.domain.feed
+
+import com.prof18.feedflow.core.domain.HtmlParser
+import com.prof18.feedflow.shared.domain.HtmlRetriever
+import com.prof18.feedflow.shared.test.TestDispatcherProvider.testDispatcher
+import com.prof18.feedflow.shared.test.testLogger
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FeedSourceLogoRetrieverImplTest {
+
+    @Test
+    fun `resolves root relative favicon against website domain`() = runTest(testDispatcher) {
+        val retriever = createRetriever(faviconUrl = "/public/build/images/favicon-48x48.png")
+
+        val result = retriever.getFeedSourceLogoUrl("https://www.howtogeek.com/feed/")
+
+        assertEquals(
+            expected = "https://www.howtogeek.com/public/build/images/favicon-48x48.png",
+            actual = result,
+        )
+    }
+
+    @Test
+    fun `resolves relative favicon against website domain`() = runTest(testDispatcher) {
+        val retriever = createRetriever(faviconUrl = "favicon.ico")
+
+        val result = retriever.getFeedSourceLogoUrl("https://example.com/feed.xml")
+
+        assertEquals(
+            expected = "https://example.com/favicon.ico",
+            actual = result,
+        )
+    }
+
+    @Test
+    fun `keeps absolute favicon urls unchanged`() = runTest(testDispatcher) {
+        val retriever = createRetriever(faviconUrl = "https://cdn.example.com/favicon.png")
+
+        val result = retriever.getFeedSourceLogoUrl("https://example.com/feed.xml")
+
+        assertEquals(
+            expected = "https://cdn.example.com/favicon.png",
+            actual = result,
+        )
+    }
+
+    private fun createRetriever(faviconUrl: String?): FeedSourceLogoRetrieverImpl =
+        FeedSourceLogoRetrieverImpl(
+            htmlRetriever = HtmlRetriever(
+                logger = testLogger,
+                client = HttpClient(MockEngine) {
+                    engine {
+                        addHandler {
+                            respond(
+                                content = "<html></html>",
+                                status = HttpStatusCode.OK,
+                            )
+                        }
+                    }
+                },
+            ),
+            htmlParser = object : HtmlParser {
+                override fun getTextFromHTML(html: String): String? = null
+
+                override fun getFaviconUrl(html: String): String? = faviconUrl
+
+                override fun getRssUrl(html: String): String? = null
+            },
+        )
+}


### PR DESCRIPTION
## Summary
- resolve root-relative and relative favicon URLs against the feed website domain instead of forcing `/favicon.ico`
- preserve absolute, protocol-relative, and data favicon URLs as-is
- add regression tests covering the How-To Geek case and other favicon URL shapes

## Testing
- `./gradlew :shared:jvmTest --tests "com.prof18.feedflow.shared.domain.feed.FeedSourceLogoRetrieverImplTest" -q --console=plain`
- `./gradlew detekt allTests -q --console=plain`