### PR TITLE
Add M3 Expressive Toolbar in reader

### DIFF
--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeFloatingToolbar.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeFloatingToolbar.kt
@@ -49,6 +49,8 @@ import com.prof18.feedflow.shared.ui.readermode.SliderWithPlusMinus
 import com.prof18.feedflow.shared.ui.readermode.hammerIcon
 import com.prof18.feedflow.shared.ui.style.Spacing
 import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 private data class ToolbarAction(
     val icon: ImageVector,
@@ -106,7 +108,7 @@ fun ReaderModeFloatingToolbar(
                 ),
             )
         }
-    }
+    }.toImmutableList()
 
     val trailingActions = buildList {
         if (readerModeState is ReaderModeState.Success) {
@@ -160,7 +162,7 @@ fun ReaderModeFloatingToolbar(
                 )
             }
         }
-    }
+    }.toImmutableList()
 
     Surface(
         modifier = modifier,
@@ -240,8 +242,8 @@ fun ReaderModeFloatingToolbar(
 
 @Composable
 private fun OverflowToolbarLayout(
-    leadingActions: List<ToolbarAction>,
-    trailingActions: List<ToolbarAction>,
+    leadingActions: ImmutableList<ToolbarAction>,
+    trailingActions: ImmutableList<ToolbarAction>,
     isContentVisible: Boolean,
     showOverflowMenu: Boolean,
     onShowOverflowMenu: (Boolean) -> Unit,

--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeFloatingToolbar.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeFloatingToolbar.kt
@@ -1,0 +1,249 @@
+package com.prof18.feedflow.android.readermode
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Comment
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.BookmarkAdd
+import androidx.compose.material.icons.filled.BookmarkRemove
+import androidx.compose.material.icons.filled.Comment
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.TextFields
+import androidx.compose.material3.AppBarRow
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
+import com.prof18.feedflow.core.model.FeedItemId
+import com.prof18.feedflow.core.model.ReaderModeState
+import com.prof18.feedflow.shared.ui.readermode.SliderWithPlusMinus
+import com.prof18.feedflow.shared.ui.readermode.hammerIcon
+import com.prof18.feedflow.shared.ui.style.Spacing
+import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
+
+@Composable
+fun ReaderModeFloatingToolbar(
+    readerModeState: ReaderModeState,
+    fontSize: Int,
+    expanded: Boolean,
+    canNavigatePrevious: Boolean,
+    canNavigateNext: Boolean,
+    onNavigateToPrevious: () -> Unit,
+    onNavigateToNext: () -> Unit,
+    onBookmarkClick: (FeedItemId, Boolean) -> Unit,
+    openInBrowser: (String) -> Unit,
+    onShareClick: (String, String?) -> Unit,
+    onArchiveClick: (String) -> Unit,
+    onCommentsClick: (String) -> Unit,
+    onFontSizeChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showFontSizeMenu by remember { mutableStateOf(false) }
+    val strings = LocalFeedFlowStrings.current
+
+    HorizontalFloatingToolbar(
+        modifier = modifier,
+        expanded = expanded,
+        trailingContent = {
+            if (readerModeState !is ReaderModeState.Loading) {
+                val url = readerModeState.getUrl
+                val id = readerModeState.getId
+                var isBookmarked by remember(readerModeState) {
+                    mutableStateOf(readerModeState.getIsBookmarked)
+                }
+
+                if (readerModeState is ReaderModeState.Success) {
+                    DropdownMenu(
+                        expanded = showFontSizeMenu,
+                        onDismissRequest = {
+                            showFontSizeMenu = false
+                        },
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(Spacing.regular),
+                        ) {
+                            Text(
+                                text = LocalFeedFlowStrings.current.readerModeFontSize,
+                                style = MaterialTheme.typography.titleMedium,
+                            )
+
+                            SliderWithPlusMinus(
+                                value = fontSize.toFloat(),
+                                onValueChange = {
+                                    onFontSizeChange(it.toInt())
+                                },
+                                valueRange = 12f..40f,
+                                steps = 40,
+                            )
+                        }
+                    }
+                }
+
+                AppBarRow(
+                    modifier = Modifier,
+                ) {
+                    if (readerModeState is ReaderModeState.Success) {
+                        clickableItem(
+                            onClick = { showFontSizeMenu = true },
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.TextFields,
+                                    contentDescription = null,
+                                )
+                            },
+                            label = strings.readerModeFontSize,
+                        )
+                    }
+
+                    if (id != null) {
+                        val label = if (isBookmarked) {
+                            strings.menuRemoveFromBookmark
+                        } else {
+                            strings.menuAddToBookmark
+                        }
+
+                        clickableItem(
+                            onClick = {
+                                isBookmarked = !isBookmarked
+                                onBookmarkClick(FeedItemId(id), isBookmarked)
+                            },
+                            icon = {
+                                Icon(
+                                    imageVector = if (isBookmarked) {
+                                        Icons.Default.BookmarkRemove
+                                    } else {
+                                        Icons.Default.BookmarkAdd
+                                    },
+                                    contentDescription = label,
+                                )
+                            },
+                            label = label,
+                        )
+                    }
+
+                    val archiveLabel = strings.readerModeArchiveButton
+                    if (url != null) {
+                        clickableItem(
+                            onClick = { onArchiveClick(url) },
+                            icon = {
+                                Icon(
+                                    imageVector = hammerIcon,
+                                    contentDescription = archiveLabel,
+                                )
+                            },
+                            label = archiveLabel,
+                        )
+                    }
+
+                    if (readerModeState is ReaderModeState.Success) {
+                        readerModeState.readerModeData.commentsUrl?.let { commentsUrl ->
+
+                            clickableItem(
+                                onClick = { onCommentsClick(commentsUrl) },
+                                icon = {
+                                    Icon(
+                                        imageVector = Icons.AutoMirrored.Filled.Comment,
+                                        contentDescription = strings.readerModeCommentsButtonContentDescription,
+                                    )
+                                },
+                                label = strings.readerModeCommentsButtonContentDescription,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        leadingContent = {
+            if (readerModeState !is ReaderModeState.Loading) {
+                val url = readerModeState.getUrl
+
+                if (url != null) {
+                    AppBarRow {
+                        clickableItem(
+                            onClick = {
+                                val title = (readerModeState as? ReaderModeState.Success)?.readerModeData?.title
+                                onShareClick(url, title)
+                            },
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Default.Share,
+                                    contentDescription = strings.menuShare,
+                                )
+                            },
+                            label = strings.menuShare,
+                        )
+
+                        clickableItem(
+                            onClick = { openInBrowser(url) },
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Default.Language,
+                                    contentDescription = strings.readerModeBrowserButtonContentDescription,
+                                )
+                            },
+                            label = strings.readerModeBrowserButtonContentDescription,
+                        )
+                    }
+                }
+            }
+        },
+        content = {
+            TooltipBox(
+                positionProvider =
+                TooltipDefaults.rememberTooltipPositionProvider(
+                    TooltipAnchorPosition.Above,
+                ),
+                tooltip = { PlainTooltip { Text(strings.previousArticle) } },
+                state = rememberTooltipState(),
+            ) {
+
+                IconButton(
+                    modifier = Modifier.focusProperties { canFocus = expanded },
+                    onClick = onNavigateToPrevious,
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                        contentDescription = strings.previousArticle,
+                    )
+                }
+            }
+
+            TooltipBox(
+                positionProvider =
+                    TooltipDefaults.rememberTooltipPositionProvider(
+                        TooltipAnchorPosition.Above,
+                    ),
+                tooltip = { PlainTooltip { Text(strings.nextArticle) } },
+                state = rememberTooltipState(),
+            ) {
+
+                IconButton(
+                    modifier = Modifier.focusProperties { canFocus = expanded },
+                    onClick = onNavigateToNext,
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = strings.nextArticle,
+                    )
+                }
+            }
+        },
+    )
+}

--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeFloatingToolbar.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeFloatingToolbar.kt
@@ -1,6 +1,13 @@
 package com.prof18.feedflow.android.readermode
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Comment
@@ -8,17 +15,18 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.BookmarkAdd
 import androidx.compose.material.icons.filled.BookmarkRemove
-import androidx.compose.material.icons.filled.Comment
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.outlined.TextFields
-import androidx.compose.material3.AppBarRow
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FloatingToolbarDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
@@ -29,14 +37,24 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.unit.dp
 import com.prof18.feedflow.core.model.FeedItemId
 import com.prof18.feedflow.core.model.ReaderModeState
 import com.prof18.feedflow.shared.ui.readermode.SliderWithPlusMinus
 import com.prof18.feedflow.shared.ui.readermode.hammerIcon
 import com.prof18.feedflow.shared.ui.style.Spacing
 import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
+
+private data class ToolbarAction(
+    val icon: ImageVector,
+    val label: String,
+    val onClick: () -> Unit,
+)
 
 @Composable
 fun ReaderModeFloatingToolbar(
@@ -56,194 +74,287 @@ fun ReaderModeFloatingToolbar(
     modifier: Modifier = Modifier,
 ) {
     var showFontSizeMenu by remember { mutableStateOf(false) }
+    var showOverflowMenu by remember { mutableStateOf(false) }
     val strings = LocalFeedFlowStrings.current
 
-    HorizontalFloatingToolbar(
-        modifier = modifier,
-        expanded = expanded,
-        trailingContent = {
-            if (readerModeState !is ReaderModeState.Loading) {
-                val url = readerModeState.getUrl
-                val id = readerModeState.getId
-                var isBookmarked by remember(readerModeState) {
-                    mutableStateOf(readerModeState.getIsBookmarked)
-                }
+    val url = readerModeState.getUrl
+    val id = readerModeState.getId
+    var isBookmarked by remember(readerModeState) {
+        mutableStateOf(readerModeState.getIsBookmarked)
+    }
 
-                if (readerModeState is ReaderModeState.Success) {
-                    DropdownMenu(
-                        expanded = showFontSizeMenu,
-                        onDismissRequest = {
-                            showFontSizeMenu = false
-                        },
-                    ) {
-                        Column(
-                            modifier = Modifier.padding(Spacing.regular),
-                        ) {
-                            Text(
-                                text = LocalFeedFlowStrings.current.readerModeFontSize,
-                                style = MaterialTheme.typography.titleMedium,
-                            )
+    val isContentVisible = expanded && readerModeState !is ReaderModeState.Loading
 
-                            SliderWithPlusMinus(
-                                value = fontSize.toFloat(),
-                                onValueChange = {
-                                    onFontSizeChange(it.toInt())
-                                },
-                                valueRange = 12f..40f,
-                                steps = 40,
-                            )
-                        }
-                    }
-                }
-
-                AppBarRow(
-                    modifier = Modifier,
-                ) {
-                    if (readerModeState is ReaderModeState.Success) {
-                        clickableItem(
-                            onClick = { showFontSizeMenu = true },
-                            icon = {
-                                Icon(
-                                    imageVector = Icons.Outlined.TextFields,
-                                    contentDescription = null,
-                                )
-                            },
-                            label = strings.readerModeFontSize,
-                        )
-                    }
-
-                    if (id != null) {
-                        val label = if (isBookmarked) {
-                            strings.menuRemoveFromBookmark
-                        } else {
-                            strings.menuAddToBookmark
-                        }
-
-                        clickableItem(
-                            onClick = {
-                                isBookmarked = !isBookmarked
-                                onBookmarkClick(FeedItemId(id), isBookmarked)
-                            },
-                            icon = {
-                                Icon(
-                                    imageVector = if (isBookmarked) {
-                                        Icons.Default.BookmarkRemove
-                                    } else {
-                                        Icons.Default.BookmarkAdd
-                                    },
-                                    contentDescription = label,
-                                )
-                            },
-                            label = label,
-                        )
-                    }
-
-                    val archiveLabel = strings.readerModeArchiveButton
-                    if (url != null) {
-                        clickableItem(
-                            onClick = { onArchiveClick(url) },
-                            icon = {
-                                Icon(
-                                    imageVector = hammerIcon,
-                                    contentDescription = archiveLabel,
-                                )
-                            },
-                            label = archiveLabel,
-                        )
-                    }
-
-                    if (readerModeState is ReaderModeState.Success) {
-                        readerModeState.readerModeData.commentsUrl?.let { commentsUrl ->
-
-                            clickableItem(
-                                onClick = { onCommentsClick(commentsUrl) },
-                                icon = {
-                                    Icon(
-                                        imageVector = Icons.AutoMirrored.Filled.Comment,
-                                        contentDescription = strings.readerModeCommentsButtonContentDescription,
-                                    )
-                                },
-                                label = strings.readerModeCommentsButtonContentDescription,
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        leadingContent = {
-            if (readerModeState !is ReaderModeState.Loading) {
-                val url = readerModeState.getUrl
-
-                if (url != null) {
-                    AppBarRow {
-                        clickableItem(
-                            onClick = {
-                                val title = (readerModeState as? ReaderModeState.Success)?.readerModeData?.title
-                                onShareClick(url, title)
-                            },
-                            icon = {
-                                Icon(
-                                    imageVector = Icons.Default.Share,
-                                    contentDescription = strings.menuShare,
-                                )
-                            },
-                            label = strings.menuShare,
-                        )
-
-                        clickableItem(
-                            onClick = { openInBrowser(url) },
-                            icon = {
-                                Icon(
-                                    imageVector = Icons.Default.Language,
-                                    contentDescription = strings.readerModeBrowserButtonContentDescription,
-                                )
-                            },
-                            label = strings.readerModeBrowserButtonContentDescription,
-                        )
-                    }
-                }
-            }
-        },
-        content = {
-            TooltipBox(
-                positionProvider =
-                TooltipDefaults.rememberTooltipPositionProvider(
-                    TooltipAnchorPosition.Above,
+    // Build action lists regardless of isContentVisible so AnimatedVisibility can animate exit
+    val leadingActions = buildList {
+        if (readerModeState !is ReaderModeState.Loading && url != null) {
+            add(
+                ToolbarAction(
+                    icon = Icons.Default.Share,
+                    label = strings.menuShare,
+                    onClick = {
+                        val title = (readerModeState as? ReaderModeState.Success)?.readerModeData?.title
+                        onShareClick(url, title)
+                    },
                 ),
-                tooltip = { PlainTooltip { Text(strings.previousArticle) } },
-                state = rememberTooltipState(),
-            ) {
+            )
+            add(
+                ToolbarAction(
+                    icon = Icons.Default.Language,
+                    label = strings.readerModeBrowserButtonContentDescription,
+                    onClick = { openInBrowser(url) },
+                ),
+            )
+        }
+    }
 
-                IconButton(
-                    modifier = Modifier.focusProperties { canFocus = expanded },
-                    onClick = onNavigateToPrevious,
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                        contentDescription = strings.previousArticle,
-                    )
-                }
+    val trailingActions = buildList {
+        if (readerModeState is ReaderModeState.Success) {
+            add(
+                ToolbarAction(
+                    icon = Icons.Outlined.TextFields,
+                    label = strings.readerModeFontSize,
+                    onClick = { showFontSizeMenu = true },
+                ),
+            )
+        }
+        if (id != null) {
+            val bookmarkLabel = if (isBookmarked) {
+                strings.menuRemoveFromBookmark
+            } else {
+                strings.menuAddToBookmark
             }
+            val bookmarkIcon = if (isBookmarked) {
+                Icons.Default.BookmarkRemove
+            } else {
+                Icons.Default.BookmarkAdd
+            }
+            add(
+                ToolbarAction(
+                    icon = bookmarkIcon,
+                    label = bookmarkLabel,
+                    onClick = {
+                        isBookmarked = !isBookmarked
+                        onBookmarkClick(FeedItemId(id), isBookmarked)
+                    },
+                ),
+            )
+        }
+        if (url != null) {
+            add(
+                ToolbarAction(
+                    icon = hammerIcon,
+                    label = strings.readerModeArchiveButton,
+                    onClick = { onArchiveClick(url) },
+                ),
+            )
+        }
+        if (readerModeState is ReaderModeState.Success) {
+            readerModeState.readerModeData.commentsUrl?.let { commentsUrl ->
+                add(
+                    ToolbarAction(
+                        icon = Icons.AutoMirrored.Filled.Comment,
+                        label = strings.readerModeCommentsButtonContentDescription,
+                        onClick = { onCommentsClick(commentsUrl) },
+                    ),
+                )
+            }
+        }
+    }
 
-            TooltipBox(
-                positionProvider =
-                    TooltipDefaults.rememberTooltipPositionProvider(
+    Surface(
+        modifier = modifier,
+        shape = FloatingToolbarDefaults.ContainerShape,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shadowElevation = 6.dp,
+    ) {
+        Box {
+            OverflowToolbarLayout(
+                leadingActions = leadingActions,
+                trailingActions = trailingActions,
+                isContentVisible = isContentVisible,
+                showOverflowMenu = showOverflowMenu,
+                onShowOverflowMenu = { showOverflowMenu = it },
+                modifier = Modifier.padding(horizontal = 12.dp),
+            ) {
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
                         TooltipAnchorPosition.Above,
                     ),
-                tooltip = { PlainTooltip { Text(strings.nextArticle) } },
-                state = rememberTooltipState(),
-            ) {
-
-                IconButton(
-                    modifier = Modifier.focusProperties { canFocus = expanded },
-                    onClick = onNavigateToNext,
+                    tooltip = { PlainTooltip { Text(strings.previousArticle) } },
+                    state = rememberTooltipState(),
                 ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                        contentDescription = strings.nextArticle,
+                    IconButton(
+                        modifier = Modifier.focusProperties { canFocus = expanded },
+                        enabled = canNavigatePrevious,
+                        onClick = onNavigateToPrevious,
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                            contentDescription = strings.previousArticle,
+                        )
+                    }
+                }
+
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(
+                        TooltipAnchorPosition.Above,
+                    ),
+                    tooltip = { PlainTooltip { Text(strings.nextArticle) } },
+                    state = rememberTooltipState(),
+                ) {
+                    IconButton(
+                        modifier = Modifier.focusProperties { canFocus = expanded },
+                        enabled = canNavigateNext,
+                        onClick = onNavigateToNext,
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = strings.nextArticle,
+                        )
+                    }
+                }
+            }
+
+            DropdownMenu(
+                expanded = showFontSizeMenu,
+                onDismissRequest = { showFontSizeMenu = false },
+            ) {
+                Column(modifier = Modifier.padding(Spacing.regular)) {
+                    Text(
+                        text = strings.readerModeFontSize,
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    SliderWithPlusMinus(
+                        value = fontSize.toFloat(),
+                        onValueChange = { onFontSizeChange(it.toInt()) },
+                        valueRange = 12f..40f,
+                        steps = 40,
                     )
                 }
             }
-        },
-    )
+        }
+    }
+}
+
+@Composable
+private fun OverflowToolbarLayout(
+    leadingActions: List<ToolbarAction>,
+    trailingActions: List<ToolbarAction>,
+    isContentVisible: Boolean,
+    showOverflowMenu: Boolean,
+    onShowOverflowMenu: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    fixedContent: @Composable () -> Unit,
+) {
+    SubcomposeLayout(modifier) { constraints ->
+        // Measure a sample IconButton to get standard item dimensions
+        val samplePlaceable = subcompose("sample") {
+            IconButton(onClick = {}) { Icon(Icons.Default.MoreVert, null) }
+        }.first().measure(constraints.copy(minWidth = 0))
+        val itemWidth = samplePlaceable.width
+
+        val fixedCount = 2 // prev + next
+        val fixedWidth = fixedCount * itemWidth
+
+        val allActions = leadingActions + trailingActions
+        val availableForActions = if (constraints.hasBoundedWidth) {
+            constraints.maxWidth - fixedWidth
+        } else {
+            Int.MAX_VALUE
+        }
+        val maxActionSlots = if (availableForActions == Int.MAX_VALUE) {
+            allActions.size
+        } else {
+            (availableForActions / itemWidth).coerceAtLeast(0)
+        }
+
+        val needsOverflow = allActions.size > maxActionSlots
+        val visibleCount = if (needsOverflow) {
+            (maxActionSlots - 1).coerceAtLeast(0)
+        } else {
+            allActions.size
+        }
+
+        // Split visible count: leading first, then trailing fills remaining
+        val visibleLeading = minOf(visibleCount, leadingActions.size)
+        val visibleTrailing = (visibleCount - visibleLeading).coerceIn(0, trailingActions.size)
+        val overflowActions = leadingActions.drop(visibleLeading) + trailingActions.drop(visibleTrailing)
+
+        val contentPlaceable = subcompose("content") {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                AnimatedVisibility(
+                    visible = isContentVisible && visibleLeading > 0,
+                    enter = fadeIn() + expandHorizontally(),
+                    exit = shrinkHorizontally() + fadeOut(),
+                ) {
+                    Row {
+                        leadingActions.take(visibleLeading).forEach { action ->
+                            IconButton(onClick = action.onClick) {
+                                Icon(
+                                    imageVector = action.icon,
+                                    contentDescription = action.label,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                fixedContent()
+
+                AnimatedVisibility(
+                    visible = isContentVisible && (visibleTrailing > 0 || needsOverflow),
+                    enter = fadeIn() + expandHorizontally(),
+                    exit = shrinkHorizontally() + fadeOut(),
+                ) {
+                    Row {
+                        trailingActions.take(visibleTrailing).forEach { action ->
+                            IconButton(onClick = action.onClick) {
+                                Icon(
+                                    imageVector = action.icon,
+                                    contentDescription = action.label,
+                                )
+                            }
+                        }
+
+                        if (needsOverflow) {
+                            Box {
+                                IconButton(onClick = { onShowOverflowMenu(true) }) {
+                                    Icon(
+                                        imageVector = Icons.Default.MoreVert,
+                                        contentDescription = null,
+                                    )
+                                }
+                                DropdownMenu(
+                                    expanded = showOverflowMenu,
+                                    onDismissRequest = { onShowOverflowMenu(false) },
+                                ) {
+                                    overflowActions.forEach { action ->
+                                        DropdownMenuItem(
+                                            text = { Text(action.label) },
+                                            onClick = {
+                                                action.onClick()
+                                                onShowOverflowMenu(false)
+                                            },
+                                            leadingIcon = {
+                                                Icon(
+                                                    imageVector = action.icon,
+                                                    contentDescription = null,
+                                                )
+                                            },
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }.first().measure(constraints.copy(minWidth = 0))
+
+        layout(contentPlaceable.width, contentPlaceable.height) {
+            contentPlaceable.placeRelative(0, 0)
+        }
+    }
 }

--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeScreen.android.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeScreen.android.kt
@@ -1,20 +1,18 @@
 package com.prof18.feedflow.android.readermode
 
 import android.webkit.CookieManager
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material3.AppBarRow
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingToolbarDefaults.ScreenOffset
-import androidx.compose.material3.HorizontalFloatingToolbar
-import androidx.compose.material3.Icon
+import androidx.compose.material3.FloatingToolbarDefaults.floatingToolbarVerticalNestedScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -24,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,7 +46,6 @@ import com.prof18.feedflow.core.model.ThemeMode
 import com.prof18.feedflow.shared.domain.ReaderColors
 import com.prof18.feedflow.shared.domain.getReaderModeStyledHtml
 import com.prof18.feedflow.shared.ui.style.Spacing
-import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
 import com.prof18.feedflow.shared.utils.getArchiveISUrl
 import com.prof18.feedflow.shared.utils.isValidUrl
 import org.koin.compose.koinInject
@@ -72,6 +70,15 @@ internal fun ReaderModeScreen(
     val context = LocalContext.current
     val navigator = rememberWebViewNavigator()
     var fullscreenImageUrl by remember { mutableStateOf<String?>(null) }
+    var toolbarExpanded by rememberSaveable { mutableStateOf(true) }
+    val scrollState = rememberScrollState()
+    val isAtBottom by remember {
+        derivedStateOf {
+            scrollState.value >= scrollState.maxValue && scrollState.maxValue > 0
+        }
+    }
+
+    LaunchedEffect(isAtBottom) { if (isAtBottom) toolbarExpanded = true }
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -79,8 +86,6 @@ internal fun ReaderModeScreen(
         Scaffold(
             topBar = {
                 ReaderModeToolbar(
-                    readerModeState = readerModeState,
-                    fontSize = fontSize,
                     navigateBack = {
                         if (navigator.canGoBack) {
                             navigator.navigateBack()
@@ -90,84 +95,62 @@ internal fun ReaderModeScreen(
                     },
                     isDetailFullscreen = isDetailFullscreen,
                     onToggleDetailFullscreen = onToggleDetailFullscreen,
-                    openInBrowser = { url ->
-                        if (isValidUrl(url)) {
-                            browserManager.openUrlWithFavoriteBrowser(url, context)
-                        }
-                    },
-                    onShareClick = { url, title ->
-                        context.openShareSheet(
-                            title = title,
-                            url = url,
-                        )
-                    },
-                    onArchiveClick = { articleUrl ->
-                        val archiveUrl = getArchiveISUrl(articleUrl)
-                        if (isValidUrl(archiveUrl)) {
-                            browserManager.openUrlWithFavoriteBrowser(archiveUrl, context)
-                        }
-                    },
-                    onCommentsClick = { commentsUrl ->
-                        if (isValidUrl(commentsUrl)) {
-                            browserManager.openUrlWithFavoriteBrowser(commentsUrl, context)
-                        }
-                    },
-                    onFontSizeChange = { newFontSize ->
-                        navigator.evaluateJavaScript(
-                            """
-                            document.getElementById("container").style.fontSize = "$newFontSize" + "px";
-                            document.getElementById("container").style.lineHeight = "1.5em";
-                            """.trimIndent(),
-                        )
-                        onUpdateFontSize(newFontSize)
-                    },
-                    onBookmarkClick = onBookmarkClick,
                 )
             },
+
         ) { contentPadding ->
             Box(
                 modifier = Modifier,
             ) {
                 if (readerModeState !is ReaderModeState.Loading) {
-                    val strings = LocalFeedFlowStrings.current
-
-                    HorizontalFloatingToolbar(
-                        modifier = Modifier
-                            .align(Alignment.BottomEnd)
+                    ReaderModeFloatingToolbar(
+                        modifier = Modifier.align(Alignment.BottomCenter)
                             .offset(y = -ScreenOffset)
                             .zIndex(1f)
-                            .padding(end = Spacing.regular)
-                            .padding(bottom = contentPadding.calculateBottomPadding()),
-                        expanded = true,
-                        content = {
-                            AppBarRow(
-                                modifier = Modifier,
-                            ) {
-                                clickableItem(
-                                    onClick = onNavigateToPrevious,
-                                    enabled = canNavigatePrevious,
-                                    icon = {
-                                        Icon(
-                                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
-                                            contentDescription = strings.previousArticle,
-                                        )
-                                    },
-                                    label = strings.previousArticle,
-                                )
-
-                                clickableItem(
-                                    onClick = onNavigateToNext,
-                                    enabled = canNavigateNext,
-                                    icon = {
-                                        Icon(
-                                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                                            contentDescription = strings.nextArticle,
-                                        )
-                                    },
-                                    label = strings.nextArticle,
-                                )
+                            .padding(
+                                start = Spacing.small,
+                                end = Spacing.small,
+                                bottom = contentPadding.calculateBottomPadding()
+                            ),
+                        expanded = toolbarExpanded,
+                        readerModeState = readerModeState,
+                        fontSize = fontSize,
+                        openInBrowser = { url ->
+                            if (isValidUrl(url)) {
+                                browserManager.openUrlWithFavoriteBrowser(url, context)
                             }
                         },
+                        onShareClick = { url, title ->
+                            context.openShareSheet(
+                                title = title,
+                                url = url,
+                            )
+                        },
+                        onArchiveClick = { articleUrl ->
+                            val archiveUrl = getArchiveISUrl(articleUrl)
+                            if (isValidUrl(archiveUrl)) {
+                                browserManager.openUrlWithFavoriteBrowser(archiveUrl, context)
+                            }
+                        },
+                        onCommentsClick = { commentsUrl ->
+                            if (isValidUrl(commentsUrl)) {
+                                browserManager.openUrlWithFavoriteBrowser(commentsUrl, context)
+                            }
+                        },
+                        onFontSizeChange = { newFontSize ->
+                            navigator.evaluateJavaScript(
+                                """
+        document.getElementById("container").style.fontSize = "$newFontSize" + "px";
+        document.getElementById("container").style.lineHeight = "1.5em";
+                                """.trimIndent(),
+                            )
+                            onUpdateFontSize(newFontSize)
+                        },
+                        onBookmarkClick = onBookmarkClick,
+                        canNavigatePrevious = canNavigatePrevious,
+                        canNavigateNext = canNavigateNext,
+                        onNavigateToPrevious = onNavigateToPrevious,
+                        onNavigateToNext = onNavigateToNext,
                     )
                 }
 
@@ -179,6 +162,7 @@ internal fun ReaderModeScreen(
                             navigator = navigator,
                         )
                     }
+
                     ReaderModeState.Loading -> {
                         Box(
                             contentAlignment = Alignment.Center,
@@ -189,8 +173,15 @@ internal fun ReaderModeScreen(
                             CircularProgressIndicator()
                         }
                     }
+
                     is ReaderModeState.Success -> {
                         ReaderMode(
+                            modifier = Modifier.floatingToolbarVerticalNestedScroll(
+                                expanded = toolbarExpanded,
+                                onExpand = { toolbarExpanded = true },
+                                onCollapse = { toolbarExpanded = false },
+                            ),
+                            scrollState = scrollState,
                             readerModeState = readerModeState,
                             openInBrowser = { url ->
                                 if (isValidUrl(url)) {
@@ -244,6 +235,8 @@ private fun ReaderMode(
     onImageClick: (String) -> Unit,
     contentPadding: PaddingValues,
     navigator: WebViewNavigator,
+    modifier: Modifier = Modifier,
+    scrollState: ScrollState = rememberScrollState(),
 ) {
     val bodyColor = MaterialTheme.colorScheme.onSurface.toArgb().toHexString().substring(2)
     val linkColor = MaterialTheme.colorScheme.primary.toArgb().toHexString().substring(2)
@@ -328,8 +321,9 @@ private fun ReaderMode(
 
     val layoutDir = LocalLayoutDirection.current
     WebView(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
+            .verticalScroll(scrollState)
             .padding(top = contentPadding.calculateTopPadding())
             .padding(start = contentPadding.calculateLeftPadding(layoutDir))
             .padding(end = contentPadding.calculateRightPadding(layoutDir)),

--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeScreen.android.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeScreen.android.kt
@@ -110,7 +110,7 @@ internal fun ReaderModeScreen(
                             .padding(
                                 start = Spacing.small,
                                 end = Spacing.small,
-                                bottom = contentPadding.calculateBottomPadding()
+                                bottom = contentPadding.calculateBottomPadding(),
                             ),
                         expanded = toolbarExpanded,
                         readerModeState = readerModeState,

--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeToolbar.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeToolbar.kt
@@ -1,65 +1,36 @@
 package com.prof18.feedflow.android.readermode
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.BookmarkAdd
-import androidx.compose.material.icons.filled.BookmarkRemove
-import androidx.compose.material.icons.filled.Comment
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material.icons.filled.Fullscreen
-import androidx.compose.material.icons.filled.Language
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.outlined.TextFields
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PlainTooltip
-import androidx.compose.material3.Text
-import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberTooltipState
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.prof18.feedflow.core.model.FeedItemId
-import com.prof18.feedflow.core.model.ReaderModeState
-import com.prof18.feedflow.shared.ui.readermode.SliderWithPlusMinus
-import com.prof18.feedflow.shared.ui.readermode.hammerIcon
-import com.prof18.feedflow.shared.ui.style.Spacing
-import com.prof18.feedflow.shared.ui.utils.LocalFeedFlowStrings
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 @Composable
 internal fun ReaderModeToolbar(
-    readerModeState: ReaderModeState,
-    fontSize: Int,
     navigateBack: () -> Unit,
-    openInBrowser: (String) -> Unit,
-    onShareClick: (String, String?) -> Unit,
-    onArchiveClick: (String) -> Unit,
-    onCommentsClick: (String) -> Unit,
-    onFontSizeChange: (Int) -> Unit,
     isDetailFullscreen: Boolean = false,
     onToggleDetailFullscreen: (() -> Unit)? = null,
-    onBookmarkClick: (FeedItemId, Boolean) -> Unit,
 ) {
-    var showFontSizeMenu by remember { mutableStateOf(false) }
-    var showOverflowMenu by remember { mutableStateOf(false) }
-
     TopAppBar(
         title = {},
         navigationIcon = {
-            IconButton(
+            FilledIconButton(
                 onClick = onToggleDetailFullscreen ?: navigateBack,
+                modifier = Modifier.padding(start = 8.dp),
+                colors = IconButtonDefaults.filledIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f),
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                ),
             ) {
                 Icon(
                     imageVector = if (onToggleDetailFullscreen != null && !isDetailFullscreen) {
@@ -71,194 +42,9 @@ internal fun ReaderModeToolbar(
                 )
             }
         },
-        actions = {
-            Row {
-                if (readerModeState !is ReaderModeState.Loading) {
-                    val url = readerModeState.getUrl
-                    val id = readerModeState.getId
-                    var isBookmarked by remember(readerModeState) {
-                        mutableStateOf(readerModeState.getIsBookmarked)
-                    }
-
-                    if (url != null) {
-                        TooltipBox(
-                            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                            state = rememberTooltipState(),
-                            tooltip = { PlainTooltip { Text(LocalFeedFlowStrings.current.menuShare) } },
-                        ) {
-                            IconButton(
-                                onClick = {
-                                    val title = (readerModeState as? ReaderModeState.Success)?.readerModeData?.title
-                                    onShareClick(url, title)
-                                },
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Share,
-                                    contentDescription = null,
-                                )
-                            }
-                        }
-
-                        TooltipBox(
-                            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                            state = rememberTooltipState(),
-                            tooltip = {
-                                PlainTooltip {
-                                    Text(
-                                        LocalFeedFlowStrings.current.readerModeBrowserButtonContentDescription,
-                                    )
-                                }
-                            },
-                        ) {
-                            IconButton(
-                                onClick = {
-                                    openInBrowser(url)
-                                },
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Language,
-                                    contentDescription = null,
-                                )
-                            }
-                        }
-                    }
-
-                    Box {
-                        IconButton(
-                            onClick = {
-                                showOverflowMenu = true
-                            },
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.MoreVert,
-                                contentDescription = null,
-                            )
-                        }
-
-                        DropdownMenu(
-                            expanded = showOverflowMenu,
-                            onDismissRequest = {
-                                showOverflowMenu = false
-                            },
-                        ) {
-                            if (readerModeState is ReaderModeState.Success) {
-                                DropdownMenuItem(
-                                    text = { Text(text = LocalFeedFlowStrings.current.readerModeFontSize) },
-                                    leadingIcon = {
-                                        Icon(
-                                            imageVector = Icons.Outlined.TextFields,
-                                            contentDescription = null,
-                                        )
-                                    },
-                                    onClick = {
-                                        showOverflowMenu = false
-                                        showFontSizeMenu = true
-                                    },
-                                )
-                            }
-
-                            if (id != null) {
-                                DropdownMenuItem(
-                                    text = {
-                                        val tooltipText = if (isBookmarked) {
-                                            LocalFeedFlowStrings.current.menuRemoveFromBookmark
-                                        } else {
-                                            LocalFeedFlowStrings.current.menuAddToBookmark
-                                        }
-                                        Text(text = tooltipText)
-                                    },
-                                    leadingIcon = {
-                                        Icon(
-                                            imageVector = if (isBookmarked) {
-                                                Icons.Default.BookmarkRemove
-                                            } else {
-                                                Icons.Default.BookmarkAdd
-                                            },
-                                            contentDescription = null,
-                                        )
-                                    },
-                                    onClick = {
-                                        showOverflowMenu = false
-                                        isBookmarked = !isBookmarked
-                                        onBookmarkClick(FeedItemId(id), isBookmarked)
-                                    },
-                                )
-                            }
-
-                            val archiveLabel = LocalFeedFlowStrings.current.readerModeArchiveButton
-                            if (url != null) {
-                                DropdownMenuItem(
-                                    text = {
-                                        Text(
-                                            text = archiveLabel,
-                                        )
-                                    },
-                                    leadingIcon = {
-                                        Icon(
-                                            imageVector = hammerIcon,
-                                            contentDescription = null,
-                                        )
-                                    },
-                                    onClick = {
-                                        showOverflowMenu = false
-                                        onArchiveClick(url)
-                                    },
-                                )
-                            }
-
-                            if (readerModeState is ReaderModeState.Success) {
-                                readerModeState.readerModeData.commentsUrl?.let { commentsUrl ->
-                                    DropdownMenuItem(
-                                        text = {
-                                            Text(
-                                                text = LocalFeedFlowStrings.current
-                                                    .readerModeCommentsButtonContentDescription,
-                                            )
-                                        },
-                                        leadingIcon = {
-                                            Icon(
-                                                imageVector = Icons.Default.Comment,
-                                                contentDescription = null,
-                                            )
-                                        },
-                                        onClick = {
-                                            showOverflowMenu = false
-                                            onCommentsClick(commentsUrl)
-                                        },
-                                    )
-                                }
-                            }
-                        }
-                    }
-
-                    if (readerModeState is ReaderModeState.Success) {
-                        DropdownMenu(
-                            expanded = showFontSizeMenu,
-                            onDismissRequest = {
-                                showFontSizeMenu = false
-                            },
-                        ) {
-                            Column(
-                                modifier = Modifier.padding(Spacing.regular),
-                            ) {
-                                Text(
-                                    text = LocalFeedFlowStrings.current.readerModeFontSize,
-                                    style = MaterialTheme.typography.titleMedium,
-                                )
-
-                                SliderWithPlusMinus(
-                                    value = fontSize.toFloat(),
-                                    onValueChange = {
-                                        onFontSizeChange(it.toInt())
-                                    },
-                                    valueRange = 12f..40f,
-                                    steps = 40,
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = Color.Transparent,
+            scrolledContainerColor = Color.Transparent,
+        ),
     )
 }

--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeToolbar.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/readermode/ReaderModeToolbar.kt
@@ -3,8 +3,8 @@ package com.prof18.feedflow.android.readermode
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.FilledIconButton
 import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme


### PR DESCRIPTION
This PR adds some cosmetic changes to the Reader to make it more modern and compliant with Material 3 Expressive.

## Changes
 * All the content of the action bar (but the back button) has been moved to a floating toolbar
 * The Floating Toolbar only shows Previous/Next article when collapsed
 * The Floating Toolbar shows all the buttons or an overflow menu (depending on the free space on screen) when expanded
 * The Floating Toolbar is automatically expanded when the user reaches the bottom of the article

We tried to implement this with Material's official implementation of the Floating Toolbar for Compose, but the automatic collapsing/expanding behaviour was causing some unexpected crashes on some form factors. This is why we moved to a custom-made toolbar.

<img width="400" alt="Screenshot_20260403_165109" src="https://github.com/user-attachments/assets/65437c1a-4219-41ff-ad8e-47f8bc66b4c4" />

<img width="400" alt="Screenshot_20260403_165121" src="https://github.com/user-attachments/assets/0aaecf0d-ac50-4bf8-98f9-826cf5330379" />

## Demo
Big screens
https://github.com/user-attachments/assets/40ade365-f841-40d1-a751-cf094ed128d6

Small screens
https://github.com/user-attachments/assets/75918eed-64fe-42cf-8656-b808351dcaef

