### PR TITLE
Respect feed-level open preferences in search results

### DIFF
--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/home/HomeScreen.android.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/home/HomeScreen.android.kt
@@ -269,7 +269,7 @@ private fun openUrl(
 ) {
     when (urlInfo.linkOpeningPreference) {
         LinkOpeningPreference.READER_MODE -> navigateToReaderMode(urlInfo)
-        LinkOpeningPreference.INTERNAL_BROWSER -> browserManager.openUrlWithFavoriteBrowser(urlInfo.url, context)
+        LinkOpeningPreference.INTERNAL_BROWSER -> browserManager.openWithInAppBrowser(urlInfo.url, context)
         LinkOpeningPreference.PREFERRED_BROWSER -> browserManager.openUrlWithFavoriteBrowser(urlInfo.url, context)
         LinkOpeningPreference.DEFAULT -> {
             if (browserManager.openReaderMode() && !urlInfo.shouldOpenInBrowser()) {

--- a/androidApp/src/main/kotlin/com/prof18/feedflow/android/search/SearchScreen.android.kt
+++ b/androidApp/src/main/kotlin/com/prof18/feedflow/android/search/SearchScreen.android.kt
@@ -15,6 +15,7 @@ import com.prof18.feedflow.android.openShareSheet
 import com.prof18.feedflow.core.model.FeedFontSizes
 import com.prof18.feedflow.core.model.FeedItemId
 import com.prof18.feedflow.core.model.FeedItemUrlInfo
+import com.prof18.feedflow.core.model.LinkOpeningPreference
 import com.prof18.feedflow.core.model.SearchFilter
 import com.prof18.feedflow.core.model.SearchState
 import com.prof18.feedflow.core.model.shouldOpenInBrowser
@@ -104,11 +105,12 @@ internal fun SearchScreen(
         },
         navigateBack = resetAndNavigateBack,
         onFeedItemClick = { urlInfo ->
-            if (browserManager.openReaderMode() && !urlInfo.shouldOpenInBrowser()) {
-                navigateToReaderMode(urlInfo)
-            } else {
-                browserManager.openUrlWithFavoriteBrowser(urlInfo.url, context)
-            }
+            openSearchResult(
+                urlInfo = urlInfo,
+                navigateToReaderMode = navigateToReaderMode,
+                browserManager = browserManager,
+                context = context,
+            )
             viewModel.onReadStatusClick(FeedItemId(urlInfo.id), true)
         },
         onBookmarkClick = { feedItemId, isBookmarked ->
@@ -142,6 +144,26 @@ internal fun SearchScreen(
         },
         feedItemDisplaySettings = feedItemDisplaySettings,
     )
+}
+
+private fun openSearchResult(
+    urlInfo: FeedItemUrlInfo,
+    navigateToReaderMode: (FeedItemUrlInfo) -> Unit,
+    browserManager: BrowserManager,
+    context: android.content.Context,
+) {
+    when (urlInfo.linkOpeningPreference) {
+        LinkOpeningPreference.READER_MODE -> navigateToReaderMode(urlInfo)
+        LinkOpeningPreference.INTERNAL_BROWSER -> browserManager.openWithInAppBrowser(urlInfo.url, context)
+        LinkOpeningPreference.PREFERRED_BROWSER -> browserManager.openUrlWithFavoriteBrowser(urlInfo.url, context)
+        LinkOpeningPreference.DEFAULT -> {
+            if (browserManager.openReaderMode() && !urlInfo.shouldOpenInBrowser()) {
+                navigateToReaderMode(urlInfo)
+            } else {
+                browserManager.openUrlWithFavoriteBrowser(urlInfo.url, context)
+            }
+        }
+    }
 }
 
 @PreviewPhone

--- a/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/search/SearchScreen.desktop.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/prof18/feedflow/desktop/search/SearchScreen.desktop.kt
@@ -14,11 +14,14 @@ import com.prof18.feedflow.core.model.FeedFontSizes
 import com.prof18.feedflow.core.model.FeedItemId
 import com.prof18.feedflow.core.model.FeedItemUrlInfo
 import com.prof18.feedflow.core.model.FeedSource
+import com.prof18.feedflow.core.model.LinkOpeningPreference
 import com.prof18.feedflow.core.model.SearchFilter
 import com.prof18.feedflow.core.model.SearchState
+import com.prof18.feedflow.core.model.shouldOpenInBrowser
 import com.prof18.feedflow.desktop.BrowserManager
 import com.prof18.feedflow.desktop.di.DI
 import com.prof18.feedflow.desktop.utils.copyToClipboard
+import com.prof18.feedflow.desktop.utils.sanitizeUrl
 import com.prof18.feedflow.shared.presentation.SearchViewModel
 import com.prof18.feedflow.shared.presentation.model.UIErrorState
 import com.prof18.feedflow.shared.ui.search.SearchScreenContent
@@ -99,11 +102,12 @@ internal fun SearchScreen(
             navigateBack()
         },
         onFeedItemClick = { urlInfo ->
-            if (browserManager.openReaderMode()) {
-                navigateToReaderMode(urlInfo)
-            } else {
-                uriHandler.openUri(urlInfo.url)
-            }
+            openSearchResult(
+                urlInfo = urlInfo,
+                browserManager = browserManager,
+                openUri = uriHandler::openUri,
+                navigateToReaderMode = navigateToReaderMode,
+            )
             viewModel.onReadStatusClick(FeedItemId(urlInfo.id), true)
         },
         onBookmarkClick = { feedItemId, isBookmarked ->
@@ -136,6 +140,27 @@ internal fun SearchScreen(
         },
         feedItemDisplaySettings = feedItemDisplaySettings,
     )
+}
+
+private fun openSearchResult(
+    urlInfo: FeedItemUrlInfo,
+    browserManager: BrowserManager,
+    openUri: (String) -> Unit,
+    navigateToReaderMode: (FeedItemUrlInfo) -> Unit,
+) {
+    when (urlInfo.linkOpeningPreference) {
+        LinkOpeningPreference.READER_MODE -> navigateToReaderMode(urlInfo)
+        LinkOpeningPreference.INTERNAL_BROWSER,
+        LinkOpeningPreference.PREFERRED_BROWSER,
+        -> openUri(urlInfo.url.sanitizeUrl())
+        LinkOpeningPreference.DEFAULT -> {
+            if (browserManager.openReaderMode() && !urlInfo.shouldOpenInBrowser()) {
+                navigateToReaderMode(urlInfo)
+            } else {
+                openUri(urlInfo.url.sanitizeUrl())
+            }
+        }
+    }
 }
 
 @Preview

--- a/iosApp/Source/Search/SearchScreenContent.swift
+++ b/iosApp/Source/Search/SearchScreenContent.swift
@@ -98,35 +98,57 @@ struct SearchScreenContent: View {
     }
 
     private func handleSearchItemTap(feedItem: FeedItem) {
-        if browserSelector.openReaderMode(link: feedItem.url) {
-            let urlInfo = FeedItemUrlInfo(
-                id: feedItem.id,
-                url: feedItem.url,
-                title: feedItem.title,
-                openOnlyOnBrowser: false,
-                isBookmarked: feedItem.isBookmarked,
-                linkOpeningPreference: feedItem.feedSource.linkOpeningPreference,
-                commentsUrl: feedItem.commentsUrl,
-                imageUrl: feedItem.imageUrl
-            )
+        let urlInfo = FeedItemUrlInfo(
+            id: feedItem.id,
+            url: feedItem.url,
+            title: feedItem.title,
+            openOnlyOnBrowser: false,
+            isBookmarked: feedItem.isBookmarked,
+            linkOpeningPreference: feedItem.feedSource.linkOpeningPreference,
+            commentsUrl: feedItem.commentsUrl,
+            imageUrl: feedItem.imageUrl
+        )
+
+        guard let url = URL(string: feedItem.url) else {
+            onReadStatusClick(FeedItemId(id: feedItem.id), true)
+            return
+        }
+
+        switch urlInfo.linkOpeningPreference {
+        case .readerMode:
             readerModeViewModel.getReaderModeHtml(urlInfo: urlInfo)
-            if let navigate = onReaderModeNavigate {
-                navigate()
+            navigateToReaderMode()
+        case .internalBrowser:
+            if browserSelector.isValidForInAppBrowser(url) {
+                appState.openInAppBrowser(url: url)
             } else {
-                self.appState.navigate(route: CommonViewRoute.readerMode)
+                openURL(browserSelector.getUrlForDefaultBrowser(stringUrl: feedItem.url))
             }
-        } else if browserSelector.openInAppBrowser() {
-            if let url = URL(string: feedItem.url) {
+        case .preferredBrowser:
+            openURL(browserSelector.getUrlForDefaultBrowser(stringUrl: feedItem.url))
+        case .default:
+            if browserSelector.openReaderMode(link: feedItem.url) {
+                readerModeViewModel.getReaderModeHtml(urlInfo: urlInfo)
+                navigateToReaderMode()
+            } else if browserSelector.openInAppBrowser() {
                 if browserSelector.isValidForInAppBrowser(url) {
                     appState.openInAppBrowser(url: url)
                 } else {
                     openURL(browserSelector.getUrlForDefaultBrowser(stringUrl: feedItem.url))
                 }
+            } else {
+                openURL(browserSelector.getUrlForDefaultBrowser(stringUrl: feedItem.url))
             }
-        } else {
-            openURL(browserSelector.getUrlForDefaultBrowser(stringUrl: feedItem.url))
         }
         onReadStatusClick(FeedItemId(id: feedItem.id), true)
+    }
+
+    private func navigateToReaderMode() {
+        if let navigate = onReaderModeNavigate {
+            navigate()
+        } else {
+            appState.navigate(route: CommonViewRoute.readerMode)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Make search result taps honor each feed’s `LinkOpeningPreference` on Android, desktop, and iOS
- Fix Android home item handling so `INTERNAL_BROWSER` actually opens the in-app browser
- Keep the default reader-mode fallback behavior for feeds that use the global setting

## Testing
- Local validation completed for the updated Android, desktop, and iOS handlers
- Formatting and linting passed on the Swift changes
- Kotlin compile and full shared checks passed