### PR TITLE
Remove keys from feed and search lazy lists

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/list/FeedListView.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/home/components/list/FeedListView.kt
@@ -122,7 +122,6 @@ fun FeedList(
         ) {
             itemsIndexed(
                 items = feedItems,
-                key = { _, item -> item.id },
             ) { index, item ->
                 val swipeBackgroundColor = when (feedLayout) {
                     FeedLayout.LIST -> MaterialTheme.colorScheme.surfaceContainerHighest

--- a/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/search/SearchScreenContent.kt
+++ b/sharedUI/src/commonMain/kotlin/com/prof18/feedflow/shared/ui/search/SearchScreenContent.kt
@@ -149,7 +149,7 @@ fun SearchScreenContent(
                     }
 
                     is SearchState.DataFound -> {
-                        itemsIndexed(searchState.items, key = { _, item -> item.id }) { index, item ->
+                        itemsIndexed(searchState.items) { index, item ->
                             FeedItemContainer(feedLayout = searchState.feedLayout) {
                                 FeedItemView(
                                     feedItem = item,


### PR DESCRIPTION
## Summary
- Commit `ba3104f1c` ("Add keys to lazy lists") added `key = { _, item -> item.id }` to the Home feed and search-results `itemsIndexed`. With stable id-based keys, Compose remaps items by identity on feed refresh, which conflicts with the index-based read-status tracking (`snapshotFlow { listState.firstVisibleItemIndex }`) and pagination — breaking scroll up/down while/after getting new feeds.
- Removes the `key` argument from both lazy lists (`FeedListView.kt`, `SearchScreenContent.kt`), reverting to positional keys and restoring the previous scroll behavior.

## Test plan
- [ ] Scroll the Home feed up/down, trigger a refresh / get new feeds while scrolling and right after — scrolling works normally
- [ ] Open Search, run a query, scroll the results list — scrolling works
- [ ] `./gradlew --quiet --console=plain detekt allTests` passes