### PR TITLE
pull comments link from article when fetching feeds from sync provider

### DIFF
--- a/core/src/commonMain/kotlin/com/prof18/feedflow/core/domain/HtmlParser.kt
+++ b/core/src/commonMain/kotlin/com/prof18/feedflow/core/domain/HtmlParser.kt
@@ -4,4 +4,5 @@ interface HtmlParser {
     fun getTextFromHTML(html: String): String?
     fun getFaviconUrl(html: String): String?
     fun getRssUrl(html: String): String?
+    fun extractCommentsUrl(html: String): String?
 }

--- a/feedSync/feedbin/src/commonTest/kotlin/com/prof18/feedflow/feedsync/feedbin/domain/mapping/EntryDTOMapperTest.kt
+++ b/feedSync/feedbin/src/commonTest/kotlin/com/prof18/feedflow/feedsync/feedbin/domain/mapping/EntryDTOMapperTest.kt
@@ -141,6 +141,7 @@ class EntryDTOMapperTest {
         override fun getTextFromHTML(html: String): String? = "Parsed Summary"
         override fun getFaviconUrl(html: String): String? = null
         override fun getRssUrl(html: String): String? = null
+        override fun extractCommentsUrl(html: String): String? = null
     }
 
     private class FakeDateFormatter : DateFormatter {

--- a/feedSync/greader/src/commonMain/kotlin/com/prof18/feedflow/feedsync/greader/domain/mapping/ItemContentDTOMapper.kt
+++ b/feedSync/greader/src/commonMain/kotlin/com/prof18/feedflow/feedsync/greader/domain/mapping/ItemContentDTOMapper.kt
@@ -35,7 +35,7 @@ internal class ItemContentDTOMapper(
                 dateFormat = DateFormat.NORMAL,
                 timeFormat = TimeFormat.HOURS_24,
             ),
-            commentsUrl = null,
+            commentsUrl = content?.let { htmlParser.extractCommentsUrl(it) },
             isBookmarked = itemContentDTO.starred,
         )
     }

--- a/feedSync/greader/src/commonTest/kotlin/com/prof18/feedflow/feedsync/greader/domain/mapping/ItemContentDTOMapperTest.kt
+++ b/feedSync/greader/src/commonTest/kotlin/com/prof18/feedflow/feedsync/greader/domain/mapping/ItemContentDTOMapperTest.kt
@@ -192,6 +192,43 @@ class ItemContentDTOMapperTest {
         assertEquals("0000000deadbeef", result?.id)
     }
 
+    @Test
+    fun `mapToFeedItem extracts commentsUrl from content HTML`() {
+        val itemContentDTO = createItemContentDTO(
+            canonicalHref = "https://example.com/article",
+            contentText = """<p>Article body</p><a href="https://example.com/article#comments">Comments</a>""",
+        )
+
+        val result = mapper.mapToFeedItem(itemContentDTO, testFeedSource)
+
+        assertEquals("https://example.com/article#comments", result?.commentsUrl)
+    }
+
+    @Test
+    fun `mapToFeedItem sets commentsUrl to null when content has no comments anchor`() {
+        val itemContentDTO = createItemContentDTO(
+            canonicalHref = "https://example.com/article",
+            contentText = "<p>Article body with no comments link</p>",
+        )
+
+        val result = mapper.mapToFeedItem(itemContentDTO, testFeedSource)
+
+        assertNull(result?.commentsUrl)
+    }
+
+    @Test
+    fun `mapToFeedItem sets commentsUrl to null when content is null`() {
+        val itemContentDTO = createItemContentDTO(
+            canonicalHref = "https://example.com/article",
+            contentText = null,
+            summaryText = null,
+        )
+
+        val result = mapper.mapToFeedItem(itemContentDTO, testFeedSource)
+
+        assertNull(result?.commentsUrl)
+    }
+
     private fun createItemContentDTO(
         id: String = "tag:google.com,2005:reader/item/default123",
         published: Long = 1700000000L,
@@ -225,6 +262,10 @@ class ItemContentDTOMapperTest {
         override fun getTextFromHTML(html: String): String? = html
         override fun getFaviconUrl(html: String): String? = null
         override fun getRssUrl(html: String): String? = null
+        override fun extractCommentsUrl(html: String): String? {
+            val regex = Regex("""<a\s[^>]*href="([^"]*)"[^>]*>\s*[Cc]omments\s*</a>""")
+            return regex.find(html)?.groupValues?.get(1)?.takeIf { it.isNotBlank() }
+        }
     }
 
     private class FakeDateFormatter : DateFormatter {

--- a/iosApp/Source/Utils/IosHtmlParser.swift
+++ b/iosApp/Source/Utils/IosHtmlParser.swift
@@ -71,6 +71,30 @@ class IosHtmlParser: HtmlParser {
         }
     }
 
+    func extractCommentsUrl(html: String) -> String? {
+        guard !html.isEmpty else { return nil }
+        let sanitizedHtml = sanitizeHtml(html)
+
+        do {
+            let doc: Document = try SwiftSoup.parse(sanitizedHtml)
+            let anchors = try doc.select("a")
+            for anchor in anchors {
+                let text = try anchor.text().trimmingCharacters(in: .whitespaces)
+                if text.caseInsensitiveCompare("comments") == .orderedSame {
+                    let href = try anchor.attr("href")
+                    if !href.isEmpty {
+                        return href
+                    }
+                }
+            }
+            return nil
+        } catch {
+            Deps.shared.getLogger(tag: "IosHtmlParser")
+                .e(messageString: "Error during extracting comments URL: \(error)")
+            return nil
+        }
+    }
+
     // Without this, SwiftSoup will still crash on some htmls
     private func sanitizeHtml(_ html: String) -> String {
         var sanitized = html

--- a/shared/src/commonJvmAndroidMain/kotlin/com/prof18/feedflow/shared/domain/JvmHtmlParser.kt
+++ b/shared/src/commonJvmAndroidMain/kotlin/com/prof18/feedflow/shared/domain/JvmHtmlParser.kt
@@ -42,4 +42,17 @@ internal class JvmHtmlParser(
         }
         return null
     }
+
+    override fun extractCommentsUrl(html: String): String? {
+        return try {
+            val doc = Jsoup.parse(html)
+            doc.select("a")
+                .firstOrNull { it.text().trim().equals("comments", ignoreCase = true) }
+                ?.attr("href")
+                ?.takeIf { it.isNotBlank() }
+        } catch (e: Throwable) {
+            logger.d(e) { "Unable to extract comments URL from HTML, skipping" }
+            null
+        }
+    }
 }

--- a/shared/src/commonJvmAndroidTest/kotlin/com/prof18/feedflow/shared/domain/JvmHtmlParserTest.kt
+++ b/shared/src/commonJvmAndroidTest/kotlin/com/prof18/feedflow/shared/domain/JvmHtmlParserTest.kt
@@ -147,4 +147,48 @@ class JvmHtmlParserTest {
         val text = parser.getTextFromHTML("")
         assertEquals("", text)
     }
+
+    @Test
+    fun `extractCommentsUrl returns href when anchor text is Comments`() {
+        val html = """
+            <p>Some content</p>
+            <p><a href="https://example.com/article#comments">Comments</a></p>
+        """.trimIndent()
+
+        val url = parser.extractCommentsUrl(html)
+        assertEquals("https://example.com/article#comments", url)
+    }
+
+    @Test
+    fun `extractCommentsUrl is case insensitive`() {
+        val html = """<a href="https://example.com/article#comments">COMMENTS</a>"""
+
+        val url = parser.extractCommentsUrl(html)
+        assertEquals("https://example.com/article#comments", url)
+    }
+
+    @Test
+    fun `extractCommentsUrl returns null when no comments anchor present`() {
+        val html = """
+            <p>Some content without a comments link</p>
+            <a href="https://example.com/article">Read more</a>
+        """.trimIndent()
+
+        val url = parser.extractCommentsUrl(html)
+        assertNull(url)
+    }
+
+    @Test
+    fun `extractCommentsUrl returns null for empty html`() {
+        val url = parser.extractCommentsUrl("")
+        assertNull(url)
+    }
+
+    @Test
+    fun `extractCommentsUrl returns null when comments anchor has no href`() {
+        val html = """<a>Comments</a>"""
+
+        val url = parser.extractCommentsUrl(html)
+        assertNull(url)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedSourceLogoRetrieverImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedSourceLogoRetrieverImplTest.kt
@@ -71,6 +71,8 @@ class FeedSourceLogoRetrieverImplTest {
                 override fun getFaviconUrl(html: String): String? = faviconUrl
 
                 override fun getRssUrl(html: String): String? = null
+
+                override fun extractCommentsUrl(html: String): String? = null
             },
         )
 }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/AddFeedViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/AddFeedViewModelTest.kt
@@ -270,5 +270,6 @@ class AddFeedViewModelTest : KoinTestBase() {
         override fun getTextFromHTML(html: String): String? = html
         override fun getFaviconUrl(html: String): String? = null
         override fun getRssUrl(html: String): String? = rssUrl
+        override fun extractCommentsUrl(html: String): String? = null
     }
 }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/HomeViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/HomeViewModelTest.kt
@@ -1604,5 +1604,6 @@ class HomeViewModelTest : KoinTestBase() {
         override fun getTextFromHTML(html: String): String? = html
         override fun getFaviconUrl(html: String): String? = null
         override fun getRssUrl(html: String): String? = null
+        override fun extractCommentsUrl(html: String): String? = null
     }
 }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/test/koin/TestModules.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/test/koin/TestModules.kt
@@ -109,6 +109,7 @@ object TestModules {
                 override fun getTextFromHTML(html: String): String? = null
                 override fun getFaviconUrl(html: String): String? = null
                 override fun getRssUrl(html: String): String? = null
+                override fun extractCommentsUrl(html: String): String? = null
             }
         }
         single<HtmlRetriever> {


### PR DESCRIPTION
When fetching articles from GReader-compatible sync providers (e.g. FreshRSS), the `commentsUrl` field was always `null`. This adds `extractCommentsUrl` to the `HtmlParser` interface and implements it on both JVM/Android (Jsoup) and iOS (SwiftSoup) by finding the first anchor whose text is "Comments" (case-insensitive).

The `ItemContentDTOMapper` now calls this parser method on article content HTML to populate `commentsUrl` when present.

Changes
- Added `extractCommentsUrl(html)` to `HtmlParser` interface with JVM and iOS implementations
- Updated `ItemContentDTOMapper` to extract the comments URL from article content instead of always returning null
- Updated all fake `HtmlParser` implementations in tests to satisfy the new interface method
- Added unit tests for `JvmHtmlParser` and `ItemContentDTOMapper` covering present, absent, null-content, and case-insensitive scenarios