### PR TITLE
Fix timeline pagination skipping unread articles

### DIFF
--- a/.ai/PAGINATION.md
+++ b/.ai/PAGINATION.md
@@ -1,0 +1,46 @@
+# Timeline pagination
+
+Why `selectFeeds` (`FeedItem.sq`) and the cursor handling in `FeedStateRepository`
+look the way they do.
+
+## Keyset cursor, never LIMIT/OFFSET
+
+`OFFSET` addresses rows by position: "skip the first N of whatever this query
+returns right now". The timeline filters `is_read = 0` while mark-as-read-on-scroll
+flips rows to read *as the user scrolls*, so the result set shrinks underneath and
+position N stops meaning the same row — each page then skips about a page worth of
+unread articles. That was issue #1319.
+
+A cursor addresses rows by identity instead ("the rows sorting strictly after *this*
+row"), so it survives the set changing.
+
+## The cursor is a pair
+
+`pub_date` is not unique, so it can't identify a row alone. The `ORDER BY` breaks ties
+on `url_hash`, and the cursor has to be that same `(pub_date, url_hash)` pair or paging
+lands mid-way through same-timestamped articles and repeats or skips them.
+
+## Why four branches
+
+`pub_date` is nullable, and two things collide: SQLite sorts NULLs **first with ASC,
+last with DESC**, and comparing a NULL date yields NULL rather than false — which
+`WHERE` discards just like false. A plain comparison would therefore drop every undated
+article permanently. Hence one branch per sort order, times whether the cursor itself
+is dated:
+
+| Sort | Cursor | Rows after it |
+|---|---|---|
+| DESC | dated | older dated rows, **plus all undated** (they're at the tail) |
+| DESC | undated | only undated rows further along the tiebreak |
+| ASC | dated | only later dated rows (undated already passed at the head) |
+| ASC | undated | remaining undated rows, **plus all dated** |
+
+## Easy to break
+
+- The first-page gate tests `:lastUrlHash IS NULL`, not `:lastPubDate` — a real cursor
+  can legitimately hold a NULL date, so only the `NOT NULL` hash can mean "no cursor".
+- Invalidate the cursor only *after* a query succeeds: a failed refresh leaves the list
+  on screen, so a nulled cursor re-appends page one as duplicates.
+- End of list is "last page shorter than page size", not `size % pageSize` —
+  hide-read-items removes rows from the list, so its size proves nothing.
+- The predicate must mirror the `ORDER BY` exactly. Change one, change the other.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,10 @@ When creating commits:
 - Use `ReaderModeEligibility.canOpenReaderMode` / `FeedItemUrlInfo.canOpenWebReaderMode()` as the shared gate before opening reader mode on Android, Desktop, and iOS. Ineligible links such as blank, non-http(s), media/PDF/download URLs, YouTube, and Telegram should fall back to the configured browser or `HtmlNotAvailable` behavior instead of attempting reader parsing.
 - URL-less items are a separate case: they are never web-reader eligible, but they still open in the reader from their feed content. Check `FeedItemUrlInfo.hasNoUrl()` first (it must bypass the whole `linkOpeningPreference` branch, since there is no URL any browser could open).
 
+### Timeline pagination
+- The feed list pages with a keyset cursor on `(pub_date, url_hash)`, never `LIMIT`/`OFFSET`: the timeline filters on `is_read` while mark-as-read-on-scroll mutates it mid-scroll, so a positional offset skips articles (issue #1319). Read **`.ai/PAGINATION.md`** before changing `selectFeeds` in `FeedItem.sq` or the cursor handling in `FeedStateRepository`.
+- The cursor predicate must mirror the query's `ORDER BY` exactly, including SQLite NULL placement for nullable `pub_date`; invalidate the cursor only after a query succeeds.
+
 ### Internationalization
 - String resources are located in `i18n/src/commonMain/resources/locale/values-[language]/`
 - Run .scripts/refresh-translations.sh after adding a new translation, to re-generate the kotlin code

--- a/database/src/commonMain/kotlin/com/prof18/feedflow/database/DatabaseHelper.kt
+++ b/database/src/commonMain/kotlin/com/prof18/feedflow/database/DatabaseHelper.kt
@@ -131,9 +131,10 @@ class DatabaseHelper(
     suspend fun getFeedItems(
         feedFilter: FeedFilter,
         pageSize: Long,
-        offset: Long,
         showReadItems: Boolean,
         sortOrder: FeedOrder,
+        lastPubDate: Long? = null,
+        lastUrlHash: String? = null,
     ): List<SelectFeeds> = withContext(backgroundDispatcher) {
         dbRef.feedItemQueries
             .selectFeeds(
@@ -144,8 +145,9 @@ class DatabaseHelper(
                 isBookmarked = feedFilter.getBookmarkFlag(),
                 isUncategorized = feedFilter.getIsUncategorized(),
                 isHidden = feedFilter.getIsHiddenFromTimelineFlag(),
+                lastUrlHash = lastUrlHash,
+                lastPubDate = lastPubDate,
                 pageSize = pageSize,
-                offset = offset,
             )
             .executeAsList()
     }
@@ -162,8 +164,9 @@ class DatabaseHelper(
                 isBookmarked = null,
                 isUncategorized = null,
                 isHidden = 0,
+                lastUrlHash = null,
+                lastPubDate = null,
                 pageSize = pageSize,
-                offset = 0,
             )
             .asFlow()
             .mapToList(backgroundDispatcher)

--- a/database/src/commonMain/sqldelight/com/prof18/feedflow/db/FeedItem.sq
+++ b/database/src/commonMain/sqldelight/com/prof18/feedflow/db/FeedItem.sq
@@ -66,12 +66,57 @@ AND (:feedSourceCategoryId IS NULL OR feed_source_category.id = :feedSourceCateg
 AND (:isUncategorized IS NULL OR (:isUncategorized = 1 AND feed_source.category_id IS NULL))
 AND (:isHidden IS NULL OR COALESCE(feed_source_preferences.is_hidden, 0) = :isHidden)
 AND is_blocked = 0
+-- Keyset cursor on (pub_date, url_hash), never LIMIT/OFFSET: read state changes while the user
+-- scrolls, so a positional offset skips articles. The four branches exist because pub_date is
+-- nullable and comparing a null yields NULL, not false, so undated rows need matching explicitly.
+-- Must mirror the ORDER BY below. See .ai/PAGINATION.md.
+AND (
+    :lastUrlHash IS NULL
+    OR (
+        :sortOrder = 'DESC'
+        AND (
+            (
+                :lastPubDate IS NOT NULL
+                AND (
+                    pub_date IS NULL
+                    OR pub_date < :lastPubDate
+                    OR (pub_date = :lastPubDate AND feed_item.url_hash < :lastUrlHash)
+                )
+            )
+            OR (
+                :lastPubDate IS NULL
+                AND pub_date IS NULL
+                AND feed_item.url_hash < :lastUrlHash
+            )
+        )
+    )
+    OR (
+        :sortOrder = 'ASC'
+        AND (
+            (
+                :lastPubDate IS NOT NULL
+                AND pub_date IS NOT NULL
+                AND (
+                    pub_date > :lastPubDate
+                    OR (pub_date = :lastPubDate AND feed_item.url_hash > :lastUrlHash)
+                )
+            )
+            OR (
+                :lastPubDate IS NULL
+                AND (
+                    pub_date IS NOT NULL
+                    OR feed_item.url_hash > :lastUrlHash
+                )
+            )
+        )
+    )
+)
 ORDER BY
     CASE WHEN :sortOrder = 'ASC' THEN pub_date END ASC,
     CASE WHEN :sortOrder = 'ASC' THEN feed_item.url_hash END ASC,
     CASE WHEN :sortOrder = 'DESC' THEN pub_date END DESC,
     CASE WHEN :sortOrder = 'DESC' THEN feed_item.url_hash END DESC
-LIMIT :pageSize OFFSET :offset;
+LIMIT :pageSize;
 
 selectFeedUrlsForFilter:
 SELECT feed_item.url_hash FROM feed_item

--- a/e2e/maestro/android/regression/162-pagination-scroll-read.yaml
+++ b/e2e/maestro/android/regression/162-pagination-scroll-read.yaml
@@ -1,0 +1,48 @@
+appId: com.prof18.feedflow.debug
+---
+- launchApp
+- openLink: feedflow://e2e/reset-and-seed?profile=pagination-scroll-read
+- assertVisible: "E2E seed complete"
+- tapOn:
+    id: e2e_open_app
+- assertVisible:
+    text: "E2E Scroll Read Article 001"
+
+# Scroll to the end of the first 40-item page so the scrolled-past items are queued as read.
+- scrollUntilVisible:
+    element:
+      text: "E2E Scroll Read Article 035"
+    direction: DOWN
+    timeout: 60000
+    speed: 50
+    visibilityPercentage: 30
+    waitToSettleTimeoutMs: 500
+
+# Deliberate pause longer than the 2s mark-as-read-on-scroll debounce so the read states are
+# flushed to the database before the next page is requested. Article 001 is already scrolled
+# off screen, so this optional wait always burns its full timeout.
+- extendedWaitUntil:
+    visible:
+      text: "E2E Scroll Read Article 001"
+    timeout: 4000
+    optional: true
+
+# Regression guard for issue #1319: with offset pagination over the unread-only query, the
+# flushed read items shrank the result set and every page after the first skipped ~40 unread
+# articles, so nothing between 041 and 080 was ever reachable.
+- scrollUntilVisible:
+    element:
+      text: "E2E Scroll Read Article 050: Skip Needle"
+    direction: DOWN
+    timeout: 60000
+    speed: 50
+    visibilityPercentage: 30
+    waitToSettleTimeoutMs: 500
+- scrollUntilVisible:
+    element:
+      text: "E2E Scroll Read Article 090"
+    direction: DOWN
+    timeout: 60000
+    speed: 50
+    visibilityPercentage: 30
+    waitToSettleTimeoutMs: 500

--- a/e2e/maestro/maestro-e2e-guide.md
+++ b/e2e/maestro/maestro-e2e-guide.md
@@ -64,6 +64,7 @@ Supported profiles:
 - `sync-linked-mock`
 - `sync-upload-required`
 - `large-content`
+- `pagination-scroll-read`
 - `reorder-drag`
 - `feed-content`
 

--- a/e2e/maestro/maestro-e2e-tests.html
+++ b/e2e/maestro/maestro-e2e-tests.html
@@ -247,7 +247,7 @@
     <section class="summary" aria-label="Summary">
       <div class="metric"><strong id="total-count">0</strong><span>automated flow files</span></div>
       <div class="metric"><strong>13</strong><span>smoke coverage IDs</span></div>
-      <div class="metric"><strong>57</strong><span>regression coverage IDs</span></div>
+      <div class="metric"><strong>58</strong><span>regression coverage IDs</span></div>
     </section>
 
     <div class="toolbar">
@@ -327,6 +327,7 @@
       "android/regression/159-reader-feed-content-no-url.yaml",
       "android/regression/160-reader-content-source-navigation.yaml",
       "android/regression/161-reader-no-url-no-content.yaml",
+      "android/regression/162-pagination-scroll-read.yaml",
       "android/smoke/001-first-launch-empty.yaml",
       "android/smoke/002-seeded-timeline-loads.yaml",
       "android/smoke/003-library-filters.yaml",
@@ -502,7 +503,8 @@
       "regression/157": "Android drawer reorder drag smoke.",
       "regression/158": "Empty single-source filter renders the next-feed affordance and moves to the next unread source.",
       "regression/159": "URL-less article opens in the styled feed-content reader without unavailable actions.",
-      "regression/160": "Switching between cached web and RSS content preserves the reader Back destination."
+      "regression/160": "Switching between cached web and RSS content preserves the reader Back destination.",
+      "regression/162": "Pagination keeps loading pages while mark-as-read-on-scroll flushes scrolled-past items (issue #1319)."
     };
 
     const sections = document.querySelector("#sections");

--- a/e2e/maestro/maestro-e2e-tests.md
+++ b/e2e/maestro/maestro-e2e-tests.md
@@ -3,7 +3,7 @@
 A catalog of every Maestro flow currently in the suite. For how to author, run, and debug flows see [`maestro-e2e-guide.md`](./maestro-e2e-guide.md). For a browser-friendly physical flow inventory, open [`maestro-e2e-tests.html`](./maestro-e2e-tests.html).
 
 - **Smoke** — 13 logical coverage flows, both platforms, useful as a fast confidence subset (`e2e/scripts/run-android-smoke.sh` and `e2e/scripts/run-ios-smoke.sh`). iOS has one extra physical YAML for the bookmark-filter search variant.
-- **Regression Suite** — 58 logical coverage flows for broader local/CI validation. Some IDs split into platform-specific variants or seed helper YAML files.
+- **Regression Suite** — 59 logical coverage flows for broader local/CI validation. Some IDs split into platform-specific variants or seed helper YAML files.
 - **Release Validation** — run smoke plus regression with `e2e/scripts/run-android.sh` and `e2e/scripts/run-ios.sh`.
 - **Known Limitations** — what is intentionally not covered and why
 
@@ -111,6 +111,7 @@ Run for broader functional coverage. Flow files live in `e2e/maestro/{android,io
 | REG-159 | `159-reader-feed-content-no-url.yaml` | `feed-content` | Android, iOS | URL-less item opens into the fully styled feed-content reader with its title and feed source, and omits unavailable browser and content-source actions. |
 | REG-160 | `160-reader-content-source-navigation.yaml` | `reader-mode` | Android, iOS | Switching from cached web content to RSS content does not consume the reader back action; Back returns to the feed list. |
 | REG-161 | `161-reader-no-url-no-content.yaml` | `feed-content` | Android, iOS | An item with neither a url nor feed content shows the unavailable-content message instead of an empty web view. |
+| REG-162 | `162-pagination-scroll-read.yaml` | `pagination-scroll-read` | Android | Guards issue #1319: with mark-as-read-on-scroll enabled, scrolling through 90 unread items keeps loading every following page. Offset pagination over the unread-only query skipped ~40 articles per page once scrolled-past items were flushed as read, so articles 041-080 (asserted through the 050 "Skip Needle" row) were unreachable and the list stopped early. iOS is intentionally skipped: the pagination logic lives in shared code and the Android flow covers the regression wiring. |
 
 ## Known Limitations
 
@@ -118,6 +119,7 @@ These are features intentionally not covered, with the reason recorded so they a
 
 - **iOS Share Extension via OS share sheet** — Maestro can reach `shareCell` from Safari, but the synthesized tap dispatches into MobileSafari's WebView instead of the remote-hosted `SharingUIService` popover, so the extension process never starts (Maestro/XCTest limitation on iOS 26).
 - **iOS large-dataset search (REG-134)** — XCTest hierarchy retrieval times out after opening the large search-result screen.
+- **iOS scroll-read pagination (REG-162)** — intentionally Android-only. The keyset pagination and the scroll-read flush both live in shared code, and the Android flow already exercises that wiring end to end; a second platform run would only re-test SwiftUI list scrolling.
 - **iOS search-result context-menu mutations (REG-152)** — `.searchable` view hierarchy exceeds Maestro's 30s main-thread snapshot budget. Android covers the menu; iOS is row-visibility only.
 - **iOS SwiftUI text input on the FreshRSS connect form (REG-117)** — Maestro stalls on `setClipboard` / `pasteText` into the form. FreshRSS filled-form coverage stays Android-only.
 - **OS browser launches (REG-112 / REG-137 / open-website actions)** — Default / internal / preferred-browser destinations leave the app. Only the in-app preference mutation and per-feed Reader Mode override are asserted.

--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feed/FeedStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feed/FeedStateRepository.kt
@@ -9,6 +9,7 @@ import com.prof18.feedflow.core.model.FeedOrder
 import com.prof18.feedflow.core.model.FeedUpdateStatus
 import com.prof18.feedflow.core.model.FinishedFeedUpdateStatus
 import com.prof18.feedflow.database.DatabaseHelper
+import com.prof18.feedflow.db.SelectFeeds
 import com.prof18.feedflow.shared.data.FeedAppearanceSettingsRepository
 import com.prof18.feedflow.shared.data.SettingsRepository
 import com.prof18.feedflow.shared.domain.mappers.toFeedItem
@@ -55,7 +56,10 @@ internal class FeedStateRepository(
     private val currentFeedFilterMutableState: MutableStateFlow<FeedFilter> = MutableStateFlow(FeedFilter.Timeline)
     val currentFeedFilter: StateFlow<FeedFilter> = currentFeedFilterMutableState.asStateFlow()
 
-    private var currentPage: Int = 0
+    private var lastFetchedPubDate: Long? = null
+    private var lastFetchedUrlHash: String? = null
+    private var hasMorePages: Boolean = true
+    private var isLoadingMore: Boolean = false
 
     suspend fun getFeeds() {
         pendingNewArticlesMutableState.update { 0 }
@@ -66,12 +70,11 @@ internal class FeedStateRepository(
                 databaseHelper.getFeedItems(
                     feedFilter = currentFeedFilterMutableState.value,
                     pageSize = FEED_DB_PAGE_SIZE,
-                    offset = 0,
                     showReadItems = settingsRepository.getShowReadArticlesTimeline(),
                     sortOrder = feedOrder,
                 )
             }
-            currentPage = 1
+            updateCursor(feeds)
             val settings = feedAppearanceSettingsRepository.getFeedItemMappingSettings()
 
             if (feeds.isNotEmpty()) {
@@ -100,7 +103,6 @@ internal class FeedStateRepository(
                 databaseHelper.getFeedItems(
                     feedFilter = feedFilter,
                     pageSize = FEED_DB_PAGE_SIZE,
-                    offset = 0,
                     showReadItems = settingsRepository.getShowReadArticlesTimeline(),
                     sortOrder = FeedOrder.NEWEST_FIRST,
                 )
@@ -117,22 +119,23 @@ internal class FeedStateRepository(
     }
 
     suspend fun loadMoreFeeds() {
-        // Stop loading if there are no more items
-        if (mutableFeedState.value.size % FEED_DB_PAGE_SIZE != 0L) {
+        if (!hasMorePages || isLoadingMore) {
             return
         }
+        isLoadingMore = true
         try {
             val feedOrder = feedAppearanceSettingsRepository.getFeedOrder()
             val feeds = executeWithRetry {
                 databaseHelper.getFeedItems(
                     feedFilter = currentFeedFilterMutableState.value,
                     pageSize = FEED_DB_PAGE_SIZE,
-                    offset = currentPage * FEED_DB_PAGE_SIZE,
                     showReadItems = settingsRepository.getShowReadArticlesTimeline(),
                     sortOrder = feedOrder,
+                    lastPubDate = lastFetchedPubDate,
+                    lastUrlHash = lastFetchedUrlHash,
                 )
             }
-            currentPage += 1
+            updateCursor(feeds)
             val settings = feedAppearanceSettingsRepository.getFeedItemMappingSettings()
             updateFeedState(incrementListVersion = false) { currentItems ->
                 val newList = feeds.map {
@@ -146,7 +149,19 @@ internal class FeedStateRepository(
         } catch (e: Throwable) {
             logger.d(e) { "Something wrong while getting data from Database" }
             errorMutableState.emit(DatabaseError(DatabaseErrorCode.PaginationFailed))
+        } finally {
+            isLoadingMore = false
         }
+    }
+
+    // Only ever called after a successful query: a failed one must leave the cursor pointing at
+    // the list the user is still looking at, otherwise the next page restarts from the top and is
+    // appended as duplicates. See .ai/PAGINATION.md.
+    private fun updateCursor(fetchedRows: List<SelectFeeds>) {
+        hasMorePages = fetchedRows.size == FEED_DB_PAGE_SIZE.toInt()
+        val lastRow = fetchedRows.lastOrNull()
+        lastFetchedPubDate = lastRow?.pub_date
+        lastFetchedUrlHash = lastRow?.url_hash
     }
 
     suspend fun updateFeedFilter(feedFilter: FeedFilter) {

--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/e2e/E2eSeedProfile.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/e2e/E2eSeedProfile.kt
@@ -20,6 +20,7 @@ enum class E2eSeedProfile(val queryValue: String) {
     SYNC_LINKED_MOCK("sync-linked-mock"),
     SYNC_UPLOAD_REQUIRED("sync-upload-required"),
     LARGE_CONTENT("large-content"),
+    PAGINATION_SCROLL_READ("pagination-scroll-read"),
     REORDER_DRAG("reorder-drag"),
     FEED_CONTENT("feed-content"),
     ;

--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/e2e/E2eSeedRunner.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/e2e/E2eSeedRunner.kt
@@ -233,6 +233,7 @@ class E2eSeedRunner internal constructor(
             E2eSeedProfile.SYNC_LINKED_MOCK,
             E2eSeedProfile.SYNC_UPLOAD_REQUIRED,
             E2eSeedProfile.LARGE_CONTENT,
+            E2eSeedProfile.PAGINATION_SCROLL_READ,
             E2eSeedProfile.REORDER_DRAG,
             E2eSeedProfile.FEED_CONTENT,
             -> applyFeatureProfileSettings(profile, account)
@@ -271,6 +272,7 @@ class E2eSeedRunner internal constructor(
             E2eSeedProfile.SYNC_LINKED_MOCK -> applyMockLinkedAccount(account ?: E2eSeedAccount.FRESH_RSS)
             E2eSeedProfile.SYNC_UPLOAD_REQUIRED -> applySyncUploadRequiredSettings(account ?: E2eSeedAccount.FRESH_RSS)
             E2eSeedProfile.LARGE_CONTENT -> applyLargeContentSettings()
+            E2eSeedProfile.PAGINATION_SCROLL_READ -> applyPaginationScrollReadSettings()
             E2eSeedProfile.REORDER_DRAG -> applyReorderDragSettings()
             E2eSeedProfile.FEED_CONTENT -> applyFeedContentSettings()
             else -> Unit
@@ -323,6 +325,15 @@ class E2eSeedRunner internal constructor(
 
     private suspend fun applyLargeContentSettings() {
         databaseHelper.insertFeedItems(largeFeedItems, lastSyncTimestamp = SEED_NOW_MILLIS)
+    }
+
+    private suspend fun applyPaginationScrollReadSettings() {
+        // Scrolled-past items must be flushed as read while the timeline keeps hiding read items,
+        // so every new page is requested against a shrinking unread set.
+        settingsRepository.setMarkFeedAsReadWhenScrolling(true)
+        settingsRepository.setHideReadItems(false)
+        settingsRepository.setShowReadArticlesTimeline(false)
+        databaseHelper.insertFeedItems(paginationScrollReadFeedItems, lastSyncTimestamp = SEED_NOW_MILLIS)
     }
 
     private fun applySyncUploadRequiredSettings(account: E2eSeedAccount) {
@@ -810,6 +821,25 @@ class E2eSeedRunner internal constructor(
                 subtitle = "Large seeded pagination item $formattedIndex",
                 feedSource = androidWeekly,
                 url = "https://e2e.feedflow.local/large/$formattedIndex",
+                pubDateMillis = SEED_NOW_MILLIS + ONE_HOUR_MILLIS - index,
+            )
+        }
+
+        // Item 050 sits inside the 41..80 window that offset pagination used to skip once
+        // scrolled-past items were flushed as read (issue #1319).
+        private val paginationScrollReadFeedItems = (1..90).map { index ->
+            val formattedIndex = index.toString().padStart(length = 3, padChar = '0')
+            val title = if (index == 50) {
+                "E2E Scroll Read Article $formattedIndex: Skip Needle"
+            } else {
+                "E2E Scroll Read Article $formattedIndex"
+            }
+            feedItem(
+                id = "e2e-scroll-read-article-$formattedIndex",
+                title = title,
+                subtitle = "Scroll-read pagination item $formattedIndex",
+                feedSource = androidWeekly,
+                url = "https://e2e.feedflow.local/scroll-read/$formattedIndex",
                 pubDateMillis = SEED_NOW_MILLIS + ONE_HOUR_MILLIS - index,
             )
         }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryBazquxTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryBazquxTest.kt
@@ -70,7 +70,6 @@ class FeedActionsRepositoryBazquxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -108,7 +107,6 @@ class FeedActionsRepositoryBazquxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -151,7 +149,6 @@ class FeedActionsRepositoryBazquxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -195,7 +192,6 @@ class FeedActionsRepositoryBazquxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Source(dbFeedSource),
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -230,7 +226,6 @@ class FeedActionsRepositoryBazquxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -264,7 +259,6 @@ class FeedActionsRepositoryBazquxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -297,7 +291,6 @@ class FeedActionsRepositoryBazquxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -331,7 +324,6 @@ class FeedActionsRepositoryBazquxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryFeedbinFailureTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryFeedbinFailureTest.kt
@@ -62,7 +62,6 @@ class FeedActionsRepositoryFeedbinFailureTest : KoinTestBase() {
         val updatedItem = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         ).first { it.url_hash == feedItem.id }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryFeedbinTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryFeedbinTest.kt
@@ -70,7 +70,6 @@ class FeedActionsRepositoryFeedbinTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -130,7 +129,6 @@ class FeedActionsRepositoryFeedbinTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -173,7 +171,6 @@ class FeedActionsRepositoryFeedbinTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -217,7 +214,6 @@ class FeedActionsRepositoryFeedbinTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Source(dbFeedSource),
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -252,7 +248,6 @@ class FeedActionsRepositoryFeedbinTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -286,7 +281,6 @@ class FeedActionsRepositoryFeedbinTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -319,7 +313,6 @@ class FeedActionsRepositoryFeedbinTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -353,7 +346,6 @@ class FeedActionsRepositoryFeedbinTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryFreshRssFailureTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryFreshRssFailureTest.kt
@@ -64,7 +64,6 @@ class FeedActionsRepositoryFreshRssFailureTest : KoinTestBase() {
         val updatedItem = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         ).first { it.url_hash == feedItem.id }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryFreshRssTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryFreshRssTest.kt
@@ -70,7 +70,6 @@ class FeedActionsRepositoryFreshRssTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -108,7 +107,6 @@ class FeedActionsRepositoryFreshRssTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -151,7 +149,6 @@ class FeedActionsRepositoryFreshRssTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -195,7 +192,6 @@ class FeedActionsRepositoryFreshRssTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Source(dbFeedSource),
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -230,7 +226,6 @@ class FeedActionsRepositoryFreshRssTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -264,7 +259,6 @@ class FeedActionsRepositoryFreshRssTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -297,7 +291,6 @@ class FeedActionsRepositoryFreshRssTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -331,7 +324,6 @@ class FeedActionsRepositoryFreshRssTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryLocalAccountTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryLocalAccountTest.kt
@@ -106,7 +106,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
         val updatedItem = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         ).first { it.url_hash == feedItem.id }
@@ -139,7 +138,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
             val readIds = databaseHelper.getFeedItems(
                 feedFilter = FeedFilter.Timeline,
                 pageSize = 10,
-                offset = 0,
                 showReadItems = true,
                 sortOrder = FeedOrder.NEWEST_FIRST,
             ).filter { it.is_read }.map { it.url_hash }.toSet()
@@ -170,7 +168,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
             val readIds = databaseHelper.getFeedItems(
                 feedFilter = FeedFilter.Timeline,
                 pageSize = 10,
-                offset = 0,
                 showReadItems = true,
                 sortOrder = FeedOrder.OLDEST_FIRST,
             ).filter { it.is_read }.map { it.url_hash }.toSet()
@@ -199,7 +196,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
         val readIds = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         ).filter { it.is_read }.map { it.url_hash }.toSet()
@@ -229,7 +225,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Source(feedSource),
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -273,7 +268,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -332,7 +326,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.OLDEST_FIRST,
         )
@@ -385,7 +378,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -436,7 +428,6 @@ class FeedActionsRepositoryLocalAccountTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.OLDEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryMinifluxTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryMinifluxTest.kt
@@ -70,7 +70,6 @@ class FeedActionsRepositoryMinifluxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -108,7 +107,6 @@ class FeedActionsRepositoryMinifluxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -151,7 +149,6 @@ class FeedActionsRepositoryMinifluxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -195,7 +192,6 @@ class FeedActionsRepositoryMinifluxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Source(dbFeedSource),
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -230,7 +226,6 @@ class FeedActionsRepositoryMinifluxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -264,7 +259,6 @@ class FeedActionsRepositoryMinifluxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -297,7 +291,6 @@ class FeedActionsRepositoryMinifluxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -331,7 +324,6 @@ class FeedActionsRepositoryMinifluxTest : KoinTestBase() {
         val updatedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryBazquxTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryBazquxTest.kt
@@ -64,7 +64,6 @@ class FeedFetcherRepositoryBazquxTest : FeedFetcherRepositoryTestBase() {
     private suspend fun getTimelineItems() = databaseHelper.getFeedItems(
         feedFilter = FeedFilter.Timeline,
         pageSize = 50,
-        offset = 0,
         showReadItems = true,
         sortOrder = FeedOrder.NEWEST_FIRST,
     )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryFeedbinTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryFeedbinTest.kt
@@ -62,7 +62,6 @@ class FeedFetcherRepositoryFeedbinTest : FeedFetcherRepositoryTestBase() {
     private suspend fun getTimelineItems() = databaseHelper.getFeedItems(
         feedFilter = FeedFilter.Timeline,
         pageSize = 50,
-        offset = 0,
         showReadItems = true,
         sortOrder = FeedOrder.NEWEST_FIRST,
     )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryFreshRssTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryFreshRssTest.kt
@@ -64,7 +64,6 @@ class FeedFetcherRepositoryFreshRssTest : FeedFetcherRepositoryTestBase() {
     private suspend fun getTimelineItems() = databaseHelper.getFeedItems(
         feedFilter = FeedFilter.Timeline,
         pageSize = 50,
-        offset = 0,
         showReadItems = true,
         sortOrder = FeedOrder.NEWEST_FIRST,
     )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryLocalTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryLocalTest.kt
@@ -793,7 +793,6 @@ class FeedFetcherRepositoryLocalTest : FeedFetcherRepositoryTestBase() {
     private suspend fun getTimelineItems() = databaseHelper.getFeedItems(
         feedFilter = FeedFilter.Timeline,
         pageSize = 50,
-        offset = 0,
         showReadItems = true,
         sortOrder = FeedOrder.NEWEST_FIRST,
     )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryMinifluxTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedFetcherRepositoryMinifluxTest.kt
@@ -64,7 +64,6 @@ class FeedFetcherRepositoryMinifluxTest : FeedFetcherRepositoryTestBase() {
     private suspend fun getTimelineItems() = databaseHelper.getFeedItems(
         feedFilter = FeedFilter.Timeline,
         pageSize = 50,
-        offset = 0,
         showReadItems = true,
         sortOrder = FeedOrder.NEWEST_FIRST,
     )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedStateRepositoryPaginationTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedStateRepositoryPaginationTest.kt
@@ -1,0 +1,239 @@
+package com.prof18.feedflow.shared.domain.feed
+
+import app.cash.sqldelight.db.SqlDriver
+import com.prof18.feedflow.core.model.FeedItem
+import com.prof18.feedflow.core.model.FeedItemId
+import com.prof18.feedflow.core.model.FeedOrder
+import com.prof18.feedflow.core.model.FeedSource
+import com.prof18.feedflow.database.DatabaseHelper
+import com.prof18.feedflow.shared.data.FeedAppearanceSettingsRepository
+import com.prof18.feedflow.shared.data.SettingsRepository
+import com.prof18.feedflow.shared.domain.feed.FeedStateRepository.Companion.FEED_DB_PAGE_SIZE
+import com.prof18.feedflow.shared.test.FailableSqlDriver
+import com.prof18.feedflow.shared.test.KoinTestBase
+import com.prof18.feedflow.shared.test.createInMemoryDriver
+import com.prof18.feedflow.shared.test.generators.FeedItemGenerator
+import com.prof18.feedflow.shared.test.generators.FeedSourceGenerator
+import com.prof18.feedflow.shared.test.insertFeedSourceWithCategory
+import com.prof18.feedflow.shared.test.koin.TestModules
+import kotlinx.coroutines.test.runTest
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FeedStateRepositoryPaginationTest : KoinTestBase() {
+
+    private val feedStateRepository: FeedStateRepository by inject()
+    private val databaseHelper: DatabaseHelper by inject()
+    private val settingsRepository: SettingsRepository by inject()
+    private val feedAppearanceSettingsRepository: FeedAppearanceSettingsRepository by inject()
+
+    private val feedSource: FeedSource = FeedSourceGenerator.feedSource()
+
+    private val failableDriver = FailableSqlDriver(createInMemoryDriver())
+
+    override fun getTestModules(): List<Module> =
+        TestModules.createTestModules() + module {
+            single<SqlDriver> { failableDriver }
+        }
+
+    @Test
+    fun `loadMoreFeeds does not skip unread items marked as read between pages`() = runTest {
+        val itemCount = PAGE_SIZE * 2 + 10
+        val items = List(itemCount) { index ->
+            unreadItem(index, pubDate = BASE_PUB_DATE - index * PUB_DATE_STEP)
+        }
+        seed(items)
+
+        feedStateRepository.getFeeds()
+        markCurrentPageAsReadInDb()
+        feedStateRepository.loadMoreFeeds()
+        markCurrentPageAsReadInDb()
+        feedStateRepository.loadMoreFeeds()
+
+        val loadedIds = feedStateRepository.feedState.value.map { it.id }
+        assertEquals(items.map { it.id }, loadedIds)
+        assertEquals(loadedIds.size, loadedIds.toSet().size)
+    }
+
+    @Test
+    fun `loadMoreFeeds does not skip unread items marked as read between pages with oldest first`() = runTest {
+        val itemCount = PAGE_SIZE * 2 + 10
+        val items = List(itemCount) { index ->
+            unreadItem(index, pubDate = BASE_PUB_DATE + index * PUB_DATE_STEP)
+        }
+        seed(items, feedOrder = FeedOrder.OLDEST_FIRST)
+
+        feedStateRepository.getFeeds()
+        markCurrentPageAsReadInDb()
+        feedStateRepository.loadMoreFeeds()
+        markCurrentPageAsReadInDb()
+        feedStateRepository.loadMoreFeeds()
+
+        val loadedIds = feedStateRepository.feedState.value.map { it.id }
+        assertEquals(items.map { it.id }, loadedIds)
+        assertEquals(loadedIds.size, loadedIds.toSet().size)
+    }
+
+    @Test
+    fun `loadMoreFeeds stops paginating after a short page`() = runTest {
+        val itemCount = PAGE_SIZE + 10
+        val items = List(itemCount) { index ->
+            unreadItem(index, pubDate = BASE_PUB_DATE - index * PUB_DATE_STEP)
+        }
+        seed(items)
+
+        feedStateRepository.getFeeds()
+        feedStateRepository.loadMoreFeeds()
+        assertEquals(itemCount, feedStateRepository.feedState.value.size)
+
+        val olderItems = List(10) { index ->
+            unreadItem(itemCount + index, pubDate = BASE_PUB_DATE - (itemCount + index) * PUB_DATE_STEP)
+        }
+        databaseHelper.insertFeedItems(olderItems, lastSyncTimestamp = 0)
+        feedStateRepository.loadMoreFeeds()
+
+        assertEquals(itemCount, feedStateRepository.feedState.value.size)
+    }
+
+    @Test
+    fun `loadMoreFeeds keeps paginating when read items are removed from the list`() = runTest {
+        val itemCount = PAGE_SIZE * 2 + 10
+        val items = List(itemCount) { index ->
+            unreadItem(index, pubDate = BASE_PUB_DATE - index * PUB_DATE_STEP)
+        }
+        seed(items, hideReadItems = true)
+
+        feedStateRepository.getFeeds()
+        val removedIds = feedStateRepository.feedState.value.take(REMOVED_ITEMS_COUNT).map { FeedItemId(it.id) }
+        databaseHelper.updateReadStatus(removedIds, isRead = true)
+        feedStateRepository.markAsRead(removedIds.toHashSet())
+        assertEquals(PAGE_SIZE - REMOVED_ITEMS_COUNT, feedStateRepository.feedState.value.size)
+
+        feedStateRepository.loadMoreFeeds()
+
+        val expectedIds = items.map { it.id }.subList(REMOVED_ITEMS_COUNT, PAGE_SIZE * 2)
+        assertEquals(expectedIds, feedStateRepository.feedState.value.map { it.id })
+    }
+
+    @Test
+    fun `loadMoreFeeds paginates across null pub dates with newest first order`() = runTest {
+        val datedItems = List(PAGE_SIZE - 2) { index ->
+            unreadItem(index, pubDate = BASE_PUB_DATE - index * PUB_DATE_STEP)
+        }
+        val undatedItems = List(10) { index -> undatedItem(index) }
+        seed(datedItems + undatedItems)
+
+        feedStateRepository.getFeeds()
+        assertEquals(PAGE_SIZE, feedStateRepository.feedState.value.size)
+        feedStateRepository.loadMoreFeeds()
+
+        val expectedIds = datedItems.map { it.id } + undatedItems.map { it.id }.reversed()
+        assertEquals(expectedIds, feedStateRepository.feedState.value.map { it.id })
+    }
+
+    @Test
+    fun `loadMoreFeeds paginates across null pub dates with oldest first order`() = runTest {
+        val undatedItems = List(PAGE_SIZE + 5) { index -> undatedItem(index) }
+        val datedItems = List(5) { index ->
+            unreadItem(index, pubDate = BASE_PUB_DATE + index * PUB_DATE_STEP)
+        }
+        seed(undatedItems + datedItems, feedOrder = FeedOrder.OLDEST_FIRST)
+
+        feedStateRepository.getFeeds()
+        assertEquals(PAGE_SIZE, feedStateRepository.feedState.value.size)
+        feedStateRepository.loadMoreFeeds()
+
+        val expectedIds = undatedItems.map { it.id } + datedItems.map { it.id }
+        assertEquals(expectedIds, feedStateRepository.feedState.value.map { it.id })
+    }
+
+    @Test
+    fun `a failed refresh keeps the cursor so the next page does not repeat the first one`() = runTest {
+        val itemCount = PAGE_SIZE * 2 + 10
+        val items = List(itemCount) { index ->
+            unreadItem(index, pubDate = BASE_PUB_DATE - index * PUB_DATE_STEP)
+        }
+        seed(items)
+
+        feedStateRepository.getFeeds()
+        feedStateRepository.loadMoreFeeds()
+        assertEquals(PAGE_SIZE * 2, feedStateRepository.feedState.value.size)
+
+        failableDriver.failReads = true
+        feedStateRepository.getFeeds()
+        failableDriver.failReads = false
+
+        // The refresh failed, so the already loaded list is still on screen and pagination has to
+        // resume after it instead of appending the first page again.
+        assertEquals(PAGE_SIZE * 2, feedStateRepository.feedState.value.size)
+
+        feedStateRepository.loadMoreFeeds()
+
+        val loadedIds = feedStateRepository.feedState.value.map { it.id }
+        assertEquals(loadedIds.size, loadedIds.toSet().size)
+        assertEquals(items.map { it.id }, loadedIds)
+    }
+
+    @Test
+    fun `a successful refresh after a failed one restarts from the first page`() = runTest {
+        val itemCount = PAGE_SIZE * 2
+        val items = List(itemCount) { index ->
+            unreadItem(index, pubDate = BASE_PUB_DATE - index * PUB_DATE_STEP)
+        }
+        seed(items)
+
+        feedStateRepository.getFeeds()
+        feedStateRepository.loadMoreFeeds()
+
+        failableDriver.failReads = true
+        feedStateRepository.getFeeds()
+        failableDriver.failReads = false
+
+        feedStateRepository.getFeeds()
+
+        val expectedIds = items.map { it.id }.subList(0, PAGE_SIZE)
+        assertEquals(expectedIds, feedStateRepository.feedState.value.map { it.id })
+    }
+
+    private suspend fun markCurrentPageAsReadInDb() {
+        val ids = feedStateRepository.feedState.value.map { FeedItemId(it.id) }
+        databaseHelper.updateReadStatus(ids, isRead = true)
+    }
+
+    private suspend fun seed(
+        items: List<FeedItem>,
+        feedOrder: FeedOrder = FeedOrder.NEWEST_FIRST,
+        hideReadItems: Boolean = false,
+    ) {
+        settingsRepository.setShowReadArticlesTimeline(false)
+        settingsRepository.setHideReadItems(hideReadItems)
+        feedAppearanceSettingsRepository.setFeedOrder(feedOrder)
+        databaseHelper.insertFeedSourceWithCategory(feedSource)
+        databaseHelper.insertFeedItems(items, lastSyncTimestamp = 0)
+    }
+
+    private fun unreadItem(index: Int, pubDate: Long): FeedItem =
+        FeedItemGenerator.unreadFeedItem(
+            id = "item-${index.toString().padStart(ID_PADDING, '0')}",
+            feedSource = feedSource,
+            pubDateMillis = pubDate,
+        )
+
+    private fun undatedItem(index: Int): FeedItem =
+        FeedItemGenerator.unreadFeedItem(
+            id = "undated-${index.toString().padStart(ID_PADDING, '0')}",
+            feedSource = feedSource,
+            pubDateMillis = null,
+        )
+
+    private companion object {
+        val PAGE_SIZE = FEED_DB_PAGE_SIZE.toInt()
+        const val BASE_PUB_DATE = 1_704_067_200_000L
+        const val PUB_DATE_STEP = 1_000L
+        const val REMOVED_ITEMS_COUNT = 10
+        const val ID_PADDING = 3
+    }
+}

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feedsync/FeedSyncerTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feedsync/FeedSyncerTest.kt
@@ -121,7 +121,6 @@ class FeedSyncerTest : KoinTestBase() {
         val items = databaseHelper.getFeedItems(
             feedFilter = com.prof18.feedflow.core.model.FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = com.prof18.feedflow.core.model.FeedOrder.NEWEST_FIRST,
         )
@@ -211,7 +210,6 @@ class FeedSyncerTest : KoinTestBase() {
         val items = databaseHelper.getFeedItems(
             feedFilter = com.prof18.feedflow.core.model.FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = com.prof18.feedflow.core.model.FeedOrder.NEWEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/e2e/E2eSeedRunnerTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/e2e/E2eSeedRunnerTest.kt
@@ -44,7 +44,6 @@ class E2eSeedRunnerTest : KoinTestBase() {
         val timelineItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 50,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -57,7 +56,6 @@ class E2eSeedRunnerTest : KoinTestBase() {
         val bookmarkedItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Bookmarks,
             pageSize = 50,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -102,6 +100,30 @@ class E2eSeedRunnerTest : KoinTestBase() {
         assertTrue(
             feedItemContentFileHandler.isContentAvailable(E2eSeedRunner.READER_FALLBACK_ARTICLE_ID),
         )
+    }
+
+    @Test
+    fun `pagination-scroll-read profile seeds enough unread items and scroll-read settings`() = runTest {
+        seedRunner.resetAndSeed(E2eSeedProfile.PAGINATION_SCROLL_READ)
+
+        val timelineItems = databaseHelper.getFeedItems(
+            feedFilter = FeedFilter.Timeline,
+            pageSize = 200,
+            showReadItems = false,
+            sortOrder = FeedOrder.NEWEST_FIRST,
+        )
+        val scrollReadTitles = timelineItems
+            .mapNotNull { it.title }
+            .filter { it.startsWith("E2E Scroll Read Article") }
+
+        assertEquals(90, scrollReadTitles.size)
+        assertEquals("E2E Scroll Read Article 001", scrollReadTitles.first())
+        assertTrue("E2E Scroll Read Article 050: Skip Needle" in scrollReadTitles)
+        assertTrue("E2E Scroll Read Article 090" in scrollReadTitles)
+
+        assertTrue(settingsRepository.getMarkFeedAsReadWhenScrolling())
+        assertFalse(settingsRepository.getHideReadItems())
+        assertFalse(settingsRepository.getShowReadArticlesTimeline())
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/BlockedWordsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/BlockedWordsViewModelTest.kt
@@ -167,7 +167,6 @@ class BlockedWordsViewModelTest : KoinTestBase() {
         databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 20,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         ).size

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/DeeplinkFeedViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/DeeplinkFeedViewModelTest.kt
@@ -116,7 +116,6 @@ class DeeplinkFeedViewModelTest : KoinTestBase() {
         val feeds = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/HomeViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/HomeViewModelTest.kt
@@ -1891,7 +1891,6 @@ class HomeViewModelTest : KoinTestBase() {
     private suspend fun getDbItems(feedFilter: FeedFilter = FeedFilter.Timeline) = databaseHelper.getFeedItems(
         feedFilter = feedFilter,
         pageSize = 100,
-        offset = 0,
         showReadItems = true,
         sortOrder = com.prof18.feedflow.core.model.FeedOrder.NEWEST_FIRST,
     )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/ReaderModeViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/ReaderModeViewModelTest.kt
@@ -341,7 +341,6 @@ class ReaderModeViewModelTest : KoinTestBase() {
         val feeds = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/SearchViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/presentation/SearchViewModelTest.kt
@@ -414,7 +414,6 @@ class SearchViewModelTest : KoinTestBase() {
         val dbItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -463,7 +462,6 @@ class SearchViewModelTest : KoinTestBase() {
         val dbItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )
@@ -511,7 +509,6 @@ class SearchViewModelTest : KoinTestBase() {
         val dbItems = databaseHelper.getFeedItems(
             feedFilter = FeedFilter.Timeline,
             pageSize = 10,
-            offset = 0,
             showReadItems = true,
             sortOrder = FeedOrder.NEWEST_FIRST,
         )

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/test/FailableSqlDriver.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/test/FailableSqlDriver.kt
@@ -1,0 +1,50 @@
+package com.prof18.feedflow.shared.test
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+
+/**
+ * Makes reads fail on demand without closing the connection, so a test can reproduce a transient
+ * database error and then keep querying the same data.
+ */
+class FailableSqlDriver(private val delegate: SqlDriver) : SqlDriver {
+
+    var failReads: Boolean = false
+
+    override fun <R> executeQuery(
+        identifier: Int?,
+        sql: String,
+        mapper: (SqlCursor) -> QueryResult<R>,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<R> {
+        check(!failReads) { "Simulated database read failure" }
+        return delegate.executeQuery(identifier, sql, mapper, parameters, binders)
+    }
+
+    override fun execute(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<Long> = delegate.execute(identifier, sql, parameters, binders)
+
+    override fun newTransaction(): QueryResult<Transacter.Transaction> = delegate.newTransaction()
+
+    override fun currentTransaction(): Transacter.Transaction? = delegate.currentTransaction()
+
+    override fun addListener(vararg queryKeys: String, listener: Query.Listener) =
+        delegate.addListener(queryKeys = queryKeys, listener = listener)
+
+    override fun removeListener(vararg queryKeys: String, listener: Query.Listener) =
+        delegate.removeListener(queryKeys = queryKeys, listener = listener)
+
+    override fun notifyListeners(vararg queryKeys: String) =
+        delegate.notifyListeners(queryKeys = queryKeys)
+
+    override fun close() = delegate.close()
+}


### PR DESCRIPTION
The timeline paginated with `LIMIT/OFFSET` over a query that filters out read articles, so mark-as-read-on-scroll shrank the result set mid-scroll and every page after the first skipped ~40 unread articles. Replaced with a keyset cursor on `(pub_date, url_hash)`, which addresses rows by identity instead of position.

Fixes #1319.