### PR TITLE
Fix unread states being restored by cloud sync

### DIFF
--- a/feedSync/database/src/commonMain/kotlin/com/prof18/feedflow/feedsync/database/data/SyncedDatabaseHelper.kt
+++ b/feedSync/database/src/commonMain/kotlin/com/prof18/feedflow/feedsync/database/data/SyncedDatabaseHelper.kt
@@ -211,6 +211,40 @@ class SyncedDatabaseHelper(
         }
     }
 
+    suspend fun updateFeedItemsReadStatus(feedItemIds: List<FeedItemId>, isRead: Boolean) {
+        val dbRef = getDbRef()
+        dbRef.transactionWithContext(backgroundDispatcher) {
+            feedItemIds.forEach { feedItemId ->
+                dbRef.syncedFeedItemQueries.insertOrIgnoreSyncedFeedItem(
+                    url_hash = feedItemId.id,
+                    is_read = false,
+                    is_bookmarked = false,
+                )
+                dbRef.syncedFeedItemQueries.updateIsRead(
+                    isRead = isRead,
+                    urlHash = feedItemId.id,
+                )
+            }
+            dbRef.updateMetadata(SyncTable.SYNCED_FEED_ITEM)
+        }
+    }
+
+    suspend fun updateFeedItemBookmarkStatus(feedItemId: FeedItemId, isBookmarked: Boolean) {
+        val dbRef = getDbRef()
+        dbRef.transactionWithContext(backgroundDispatcher) {
+            dbRef.syncedFeedItemQueries.insertOrIgnoreSyncedFeedItem(
+                url_hash = feedItemId.id,
+                is_read = false,
+                is_bookmarked = false,
+            )
+            dbRef.syncedFeedItemQueries.updateIsBookmarked(
+                isBookmarked = isBookmarked,
+                urlHash = feedItemId.id,
+            )
+            dbRef.updateMetadata(SyncTable.SYNCED_FEED_ITEM)
+        }
+    }
+
     suspend fun isDatabaseEmpty(): Boolean = withContext(backgroundDispatcher) {
         getDbRef().syncedMetadataQueries.isSyncDatabaseEmpty().executeAsOne() == 0L
     }

--- a/feedSync/database/src/commonMain/sqldelight/com/prof18/feedflow/feedsync/database/db/SyncedFeedItem.sq
+++ b/feedSync/database/src/commonMain/sqldelight/com/prof18/feedflow/feedsync/database/db/SyncedFeedItem.sq
@@ -10,6 +10,20 @@ insertOrReplaceSyncedFeedItem:
 INSERT OR REPLACE INTO synced_feed_item(url_hash, is_read, is_bookmarked)
 VALUES (?, ?,?);
 
+insertOrIgnoreSyncedFeedItem:
+INSERT OR IGNORE INTO synced_feed_item(url_hash, is_read, is_bookmarked)
+VALUES (?, ?,?);
+
+updateIsRead:
+UPDATE synced_feed_item
+SET is_read = :isRead
+WHERE url_hash = :urlHash;
+
+updateIsBookmarked:
+UPDATE synced_feed_item
+SET is_bookmarked = :isBookmarked
+WHERE url_hash = :urlHash;
+
 deleteSyncedFeedItem:
 DELETE FROM synced_feed_item WHERE url_hash = ?;
 

--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepository.kt
@@ -88,7 +88,7 @@ internal class FeedActionsRepository(
             SyncAccounts.ICLOUD,
             -> {
                 databaseHelper.updateReadStatus(feedItemIds, isRead)
-                feedSyncRepository.setIsSyncUploadRequired()
+                feedSyncRepository.updateFeedItemsReadStatus(feedItemIds, isRead)
             }
         }
     }
@@ -289,7 +289,7 @@ internal class FeedActionsRepository(
             SyncAccounts.ICLOUD,
             -> {
                 databaseHelper.updateBookmarkStatus(feedItemId, isBookmarked)
-                feedSyncRepository.setIsSyncUploadRequired()
+                feedSyncRepository.updateFeedItemBookmarkStatus(feedItemId, isBookmarked)
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feedsync/FeedSyncRepository.kt
+++ b/shared/src/commonMain/kotlin/com/prof18/feedflow/shared/domain/feedsync/FeedSyncRepository.kt
@@ -147,6 +147,24 @@ class FeedSyncRepository internal constructor(
         }
     }
 
+    internal suspend fun updateFeedItemsReadStatus(feedItemIds: List<FeedItemId>, isRead: Boolean) {
+        if (feedSyncAccountRepository.isSyncEnabled()) {
+            withErrorHandling {
+                syncedDatabaseHelper.updateFeedItemsReadStatus(feedItemIds, isRead)
+                settingsRepository.setIsSyncUploadRequired(true)
+            }
+        }
+    }
+
+    internal suspend fun updateFeedItemBookmarkStatus(feedItemId: FeedItemId, isBookmarked: Boolean) {
+        if (feedSyncAccountRepository.isSyncEnabled()) {
+            withErrorHandling {
+                syncedDatabaseHelper.updateFeedItemBookmarkStatus(feedItemId, isBookmarked)
+                settingsRepository.setIsSyncUploadRequired(true)
+            }
+        }
+    }
+
     internal fun setIsSyncUploadRequired() {
         if (feedSyncAccountRepository.isSyncEnabled()) {
             settingsRepository.setIsSyncUploadRequired(true)
@@ -155,6 +173,13 @@ class FeedSyncRepository internal constructor(
 
     internal suspend fun syncFeedSources() {
         if (feedSyncAccountRepository.isSyncEnabled()) {
+            if (settingsRepository.getIsSyncUploadRequired()) {
+                feedSyncWorker.uploadImmediate()
+                if (settingsRepository.getIsSyncUploadRequired()) {
+                    return
+                }
+            }
+
             val result = feedSyncWorker.download()
             if (result.isError()) {
                 Logger.d { "Error on download" }

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryDropboxTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feed/FeedActionsRepositoryDropboxTest.kt
@@ -1,0 +1,89 @@
+package com.prof18.feedflow.shared.domain.feed
+
+import com.prof18.feedflow.core.model.ArticleOpenMode
+import com.prof18.feedflow.core.model.FeedItemId
+import com.prof18.feedflow.core.model.FeedSource
+import com.prof18.feedflow.core.model.SyncedFeedItem
+import com.prof18.feedflow.database.DatabaseHelper
+import com.prof18.feedflow.feedsync.database.data.SyncedDatabaseHelper
+import com.prof18.feedflow.feedsync.dropbox.DropboxSettings
+import com.prof18.feedflow.shared.data.SettingsRepository
+import com.prof18.feedflow.shared.test.KoinTestBase
+import com.prof18.feedflow.shared.test.TestDispatcherProvider.testDispatcher
+import com.prof18.feedflow.shared.test.buildFeedItem
+import com.prof18.feedflow.shared.test.insertFeedSourceWithCategory
+import kotlinx.coroutines.test.runTest
+import org.koin.test.inject
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FeedActionsRepositoryDropboxTest : KoinTestBase() {
+
+    private val feedActionsRepository: FeedActionsRepository by inject()
+    private val databaseHelper: DatabaseHelper by inject()
+    private val syncedDatabaseHelper: SyncedDatabaseHelper by inject()
+    private val dropboxSettings: DropboxSettings by inject()
+    private val settingsRepository: SettingsRepository by inject()
+
+    @Test
+    fun `marking item as unread updates Dropbox sync state`() = runTest(testDispatcher) {
+        enableDropboxSync()
+        val feedItemId = insertFeedItem()
+        databaseHelper.updateReadStatus(feedItemId, isRead = true)
+        syncedDatabaseHelper.insertFeedItems(
+            listOf(SyncedFeedItem(id = feedItemId.id, isRead = true, isBookmarked = true)),
+        )
+
+        feedActionsRepository.updateReadStatus(feedItemId, isRead = false)
+
+        val syncedItem = syncedDatabaseHelper.getAllFeedItems().single()
+        assertFalse(syncedItem.isRead)
+        assertTrue(syncedItem.isBookmarked)
+        assertTrue(settingsRepository.getIsSyncUploadRequired())
+    }
+
+    @Test
+    fun `removing bookmark updates Dropbox sync state`() = runTest(testDispatcher) {
+        enableDropboxSync()
+        val feedItemId = insertFeedItem()
+        syncedDatabaseHelper.insertFeedItems(
+            listOf(SyncedFeedItem(id = feedItemId.id, isRead = true, isBookmarked = true)),
+        )
+
+        feedActionsRepository.updateBookmarkStatus(feedItemId, isBookmarked = false)
+
+        val syncedItem = syncedDatabaseHelper.getAllFeedItems().single()
+        assertTrue(syncedItem.isRead)
+        assertFalse(syncedItem.isBookmarked)
+        assertTrue(settingsRepository.getIsSyncUploadRequired())
+    }
+
+    private fun enableDropboxSync() {
+        dropboxSettings.setDropboxData("test-credentials")
+    }
+
+    private suspend fun insertFeedItem(): FeedItemId {
+        val feedSource = createFeedSource()
+        databaseHelper.insertFeedSourceWithCategory(feedSource)
+        val feedItem = buildFeedItem("item-1", "Article 1", 10000L, feedSource)
+        databaseHelper.insertFeedItems(listOf(feedItem), lastSyncTimestamp = 0)
+        return FeedItemId(feedItem.id)
+    }
+
+    private fun createFeedSource(): FeedSource = FeedSource(
+        id = "source-1",
+        url = "https://example.com/source-1/feed.xml",
+        title = "Test Feed",
+        category = null,
+        lastSyncTimestamp = null,
+        logoUrl = null,
+        websiteUrl = "https://example.com/source-1",
+        fetchFailed = false,
+        articleOpenMode = ArticleOpenMode.DEFAULT,
+        isHiddenFromTimeline = false,
+        isPinned = false,
+        isNotificationEnabled = false,
+        isHideImagesEnabled = false,
+    )
+}

--- a/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feedsync/FeedSyncRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/prof18/feedflow/shared/domain/feedsync/FeedSyncRepositoryTest.kt
@@ -261,6 +261,30 @@ class FeedSyncRepositoryTest : KoinTestBase() {
     }
 
     @Test
+    fun `syncFeedSources uploads pending changes before downloading`() = runTest(testDispatcher) {
+        enableDropboxSync()
+        settingsRepository.setIsSyncUploadRequired(true)
+        fakeFeedSyncWorker.onUploadImmediate = {
+            settingsRepository.setIsSyncUploadRequired(false)
+        }
+
+        feedSyncRepository.syncFeedSources()
+
+        assertEquals(listOf("upload", "download", "syncSources"), fakeFeedSyncWorker.calls)
+    }
+
+    @Test
+    fun `syncFeedSources does not download when pending upload fails`() = runTest(testDispatcher) {
+        enableDropboxSync()
+        settingsRepository.setIsSyncUploadRequired(true)
+
+        feedSyncRepository.syncFeedSources()
+
+        assertEquals(listOf("upload"), fakeFeedSyncWorker.calls)
+        assertTrue(settingsRepository.getIsSyncUploadRequired())
+    }
+
+    @Test
     fun `syncFeedItems emits error to message queue`() = runTest(testDispatcher) {
         enableDropboxSync()
         val itemError = SyncResult.General(SyncFeedError.FeedItemsSyncFailed)
@@ -307,6 +331,8 @@ private class FakeFeedSyncWorker : FeedSyncWorker {
     var downloadResult: SyncResult = SyncResult.Success
     var syncFeedSourcesResult: SyncResult = SyncResult.Success
     var syncFeedItemsResult: SyncResult = SyncResult.Success
+    var onUploadImmediate: () -> Unit = {}
+    val calls = mutableListOf<String>()
 
     override fun upload() {
         uploadCallCount++
@@ -314,14 +340,20 @@ private class FakeFeedSyncWorker : FeedSyncWorker {
 
     override suspend fun uploadImmediate() {
         uploadImmediateCallCount++
+        calls.add("upload")
+        onUploadImmediate()
     }
 
     override suspend fun download(isFirstSync: Boolean): SyncResult {
+        calls.add("download")
         downloadIsFirstSyncArgs.add(isFirstSync)
         return downloadResult
     }
 
-    override suspend fun syncFeedSources(): SyncResult = syncFeedSourcesResult
+    override suspend fun syncFeedSources(): SyncResult {
+        calls.add("syncSources")
+        return syncFeedSourcesResult
+    }
 
     override suspend fun syncFeedItems(): SyncResult = syncFeedItemsResult
 }


### PR DESCRIPTION
## Summary

Fix cloud-synced articles being marked as read again after they were
explicitly changed back to unread.

The same state-storage path is shared by Dropbox, Google Drive, and
iCloud, so the fix applies to all cloud-storage sync providers.

## Steps to reproduce

1. Connect FeedFlow to Dropbox.
2. Mark one or more articles as read.
3. Open the Read section.
4. Mark those articles as unread.
5. Confirm that they move back to the timeline.
6. Refresh the feeds.

## Previous behavior

After refreshing, the articles returned to the Read section because the
old `is_read = true` values were downloaded from the cloud database and
applied again.

## Expected behavior

The unread state should be uploaded to the cloud and remain unchanged
after refreshing or syncing another device.

## Root cause

The cloud sync database intentionally stores a sparse set of article
states: articles are selected for bulk synchronization only when they
are read or bookmarked.

A previous synchronization refactor stopped writing individual negative
state transitions to the sync database. When an article changed from
read to unread, the bulk update omitted it, but its existing
`is_read = true` sync row remained. A subsequent refresh downloaded that
stale row and restored the article to read.

Refresh also downloaded the cloud database before ensuring that pending
local changes had been uploaded, allowing stale remote data to overwrite
newer local state.

## Fix

- Persist individual read/unread and bookmark/unbookmark transitions in
  the sync database.
- Insert a sync row when needed and update only the changed flag, so the
  other flag is preserved.
- Mark the cloud database for upload after the state update.
- Upload pending local changes before downloading during refresh.
- Skip the download if the pending upload does not succeed, preventing
  local changes from being overwritten.
- Add regression tests for unread and unbookmark transitions.
- Add tests for upload-before-download ordering and failed-upload
  protection.

## Why this works

An unread transition is now represented explicitly as
`is_read = false` in the cloud sync database. Refresh uploads that state
before downloading, so the downloaded database contains the new value
instead of the stale read value.

## Validation

- `./gradlew --quiet --console=plain :shared:jvmTest`
- `./gradlew --quiet --console=plain :desktopApp:compileKotlinJvm`
- `ANDROID_HOME=/Users/anton/Library/Android/sdk ./gradlew --quiet --console=plain detekt allTests`
- Manually reproduced and verified using a connected Dropbox account on
  Desktop.
- Confirmed that the upload and subsequent download used the same
  Dropbox content hash.
- Confirmed that both affected articles remained unread after refresh.